### PR TITLE
refactor(examples): share pad logic via TPadController and IPadShell

### DIFF
--- a/Examples/MarkdownPadFMX/MarkdownPadFMX.Defines.pas
+++ b/Examples/MarkdownPadFMX/MarkdownPadFMX.Defines.pas
@@ -1,0 +1,64 @@
+unit MarkdownPadFMX.Defines;
+
+// FMX-specific constants for the Markdown4D Pad demo. Values that are shared
+// verbatim with the VCL build live in MarkdownPad.Defines; only FMX-specific
+// values (window chrome, custom title bar/tooltip, TAlphaColor palette,
+// per-build strings) stay here.
+
+interface
+
+uses
+  System.UITypes,
+  MarkdownPad.Defines;
+
+const
+  WindowCaption = 'Markdown4D Pad (FMX)';
+  InitialClientWidth = 1180;
+  ToolbarHeight = 38;
+  TabControlHeight = 32;
+  CaptionButtonWidth = 46;
+  StatusBarHeight = 26;
+  ControlMargin = 6;
+  IconGlyphSize = 16;
+  TocHeaderHeight = 22;
+  SplitterWidth = 6;
+  StatusLabelWidth = 150;
+  GlyphMinimize = Char($E921);
+  GlyphMaximize = Char($E922);
+  GlyphRestore = Char($E923);
+  GlyphClose = Char($E8BB);
+  HintMinimize = 'Minimize';
+  HintMaximize = 'Maximize';
+  HintCloseWindow = 'Close';
+  ToolbarLightColor = TAlphaColor($FFF3F3F3);
+  ToolbarDarkColor = TAlphaColor($FF2D2D2D);
+  IconLightColor = TAlphaColor($FF404040);
+  IconDarkColor = TAlphaColor($FFD6D6D6);
+  SeparatorLightColor = TAlphaColor($FFD0D0D0);
+  SeparatorDarkColor = TAlphaColor($FF505050);
+  HoverLightColor = TAlphaColor($FFE0E0E0);
+  HoverDarkColor = TAlphaColor($FF3E3E3E);
+  TabActiveLightColor = TAlphaColor($FFFFFFFF);
+  TabActiveDarkColor = TAlphaColor($FF3F3F3F);
+  TabHoverLightColor = TAlphaColor($FFEAEAEA);
+  TabHoverDarkColor = TAlphaColor($FF383838);
+  CaptionCloseHoverColor = TAlphaColor($FFE81123);
+  HintBackColor = TAlphaColor($FF1E1E1E);
+  HintTextColor = TAlphaColor($FFF0F0F0);
+  HintHeight = 24;
+  HintHorizontalPadding = 8;
+  HintGap = 4;
+  HintCornerRadius = 4;
+  MarkdownExtension = '.md';
+  SessionFileName = 'MarkdownPad.Fmx.json';
+  OpenErrorFormat = 'Could not open the file:'#10'%s';
+  CloseUnsavedPrompt = 'This document has unsaved changes. Save before closing?';
+  ReloadPrompt = 'This file changed on disk. Reload and lose your local changes?';
+  PaletteListHeight = PaletteRowHeight * PaletteVisibleRows;
+  PaletteEditHeight = 30;
+  PaletteShortcutWidth = 120;
+  PaletteShortcutOpacity = 0.6;
+
+implementation
+
+end.

--- a/Examples/MarkdownPadFMX/MarkdownPadFMX.Main.pas
+++ b/Examples/MarkdownPadFMX/MarkdownPadFMX.Main.pas
@@ -30,62 +30,17 @@ uses
   MarkdownPad.EditorView,
   MarkdownPad.Session,
   MarkdownPad.Commands,
+  MarkdownPad.CommandSet,
   MarkdownPad.TabStrip.Layout,
   MarkdownPad.Fmx.TabStrip,
-  MarkdownPad.FileWatcher;
+  MarkdownPad.FileWatcher,
+  MarkdownPad.Shell,
+  MarkdownPad.Controller,
+  MarkdownPadFMX.Defines;
 
 type
-  TMarkdownPadFMXForm = class(TForm, IPadEditorView)
+  TMarkdownPadFMXForm = class(TForm, IPadEditorView, IPadShell)
   private
-    const
-      // Shared constants live in MarkdownPad.Defines; only FMX-specific values
-      // (window chrome, custom title bar/tooltip, TAlphaColor palette) stay here.
-      WindowCaption = 'Markdown4D Pad (FMX)';
-      InitialClientWidth = 1180;
-      ToolbarHeight = 38;
-      TabControlHeight = 32;
-      CaptionButtonWidth = 46;
-      StatusBarHeight = 26;
-      ControlMargin = 6;
-      IconGlyphSize = 16;
-      TocHeaderHeight = 22;
-      SplitterWidth = 6;
-      StatusLabelWidth = 150;
-      GlyphMinimize = Char($E921);
-      GlyphMaximize = Char($E922);
-      GlyphRestore = Char($E923);
-      GlyphClose = Char($E8BB);
-      HintMinimize = 'Minimize';
-      HintMaximize = 'Maximize';
-      HintCloseWindow = 'Close';
-      ToolbarLightColor = TAlphaColor($FFF3F3F3);
-      ToolbarDarkColor = TAlphaColor($FF2D2D2D);
-      IconLightColor = TAlphaColor($FF404040);
-      IconDarkColor = TAlphaColor($FFD6D6D6);
-      SeparatorLightColor = TAlphaColor($FFD0D0D0);
-      SeparatorDarkColor = TAlphaColor($FF505050);
-      HoverLightColor = TAlphaColor($FFE0E0E0);
-      HoverDarkColor = TAlphaColor($FF3E3E3E);
-      TabActiveLightColor = TAlphaColor($FFFFFFFF);
-      TabActiveDarkColor = TAlphaColor($FF3F3F3F);
-      TabHoverLightColor = TAlphaColor($FFEAEAEA);
-      TabHoverDarkColor = TAlphaColor($FF383838);
-      CaptionCloseHoverColor = TAlphaColor($FFE81123);
-      HintBackColor = TAlphaColor($FF1E1E1E);
-      HintTextColor = TAlphaColor($FFF0F0F0);
-      HintHeight = 24;
-      HintHorizontalPadding = 8;
-      HintGap = 4;
-      HintCornerRadius = 4;
-      MarkdownExtension = '.md';
-      SessionFileName = 'MarkdownPad.Fmx.json';
-      OpenErrorFormat = 'Could not open the file:'#10'%s';
-      CloseUnsavedPrompt = 'This document has unsaved changes. Save before closing?';
-      ReloadPrompt = 'This file changed on disk. Reload and lose your local changes?';
-      PaletteListHeight = PaletteRowHeight * PaletteVisibleRows;
-      PaletteEditHeight = 30;
-      PaletteShortcutWidth = 120;
-      PaletteShortcutOpacity = 0.6;
     var
       FToolbar: TRectangle;
       FTitleBar: TRectangle;
@@ -135,18 +90,11 @@ type
       FSaveDialog: TSaveDialog;
       FHtmlSaveDialog: TSaveDialog;
       FTickTimer: TTimer;
-      FTocEntries: TArray<IMarkdownTocEntry>;
       FLightTheme: TMarkdownTheme;
       FDarkTheme: TMarkdownTheme;
       FDarkThemeActive: Boolean;
-      FWorkspace: IPadWorkspace;
-      FSession: TPadSession;
-      FWatcher: TPadFileWatcher;
-      FActiveDoc: IPadDocument;
-      FMapDirty: Boolean;
-      FSwapping: Boolean;
+      FController: TPadController;
       FTocFollowing: Boolean;
-      FLastCaret: Integer;
       FFindBar: TRectangle;
       FEditorFindEdit: TEdit;
       FEditorFindCount: TLabel;
@@ -155,8 +103,6 @@ type
       FPalette: TRectangle;
       FPaletteEdit: TEdit;
       FPaletteList: TListBox;
-      FCommands: TPadCommandRegistry;
-      FPaletteMatches: TArray<TPadCommandMatch>;
       FViewMode: TPadViewMode;
       FSplitEditorWidth: Single;
       FZenActive: Boolean;
@@ -165,6 +111,39 @@ type
       FZenRightPad: TLayout;
       FZenTocWasVisible: Boolean;
       FZenFindWasVisible: Boolean;
+    // Read-through accessors to the controller-owned model state.
+    function GetWorkspace: IPadWorkspace;
+    function GetSession: TPadSession;
+    function GetMapDirty: Boolean;
+    procedure SetMapDirty(const Value: Boolean);
+    function GetSwapping: Boolean;
+    procedure SetSwapping(const Value: Boolean);
+    function GetPaletteMatches: TArray<TPadCommandMatch>;
+    property FWorkspace: IPadWorkspace read GetWorkspace;
+    property FSession: TPadSession read GetSession;
+    property FMapDirty: Boolean read GetMapDirty write SetMapDirty;
+    property FSwapping: Boolean read GetSwapping write SetSwapping;
+    property FPaletteMatches: TArray<TPadCommandMatch> read GetPaletteMatches;
+    procedure SetDocumentTitle(const Name: string);
+    procedure SetStatus(const PositionText, WordsText: string);
+    procedure SetTocCaptions(const Captions: TArray<string>);
+    procedure SetActiveTocIndex(const Index: Integer);
+    function EditorFindNeedle: string;
+    function PreviewFindNeedle: string;
+    procedure SetFindCount(const Value: string);
+    function SampleMarkdown: string;
+    function DarkThemeActive: Boolean;
+    function EffectiveViewMode: TPadViewMode;
+    procedure ApplyRestoredViewMode(const Mode: TPadViewMode);
+    function PromptOpenFile(out FileName: string): Boolean;
+    function PromptSaveFile(const SuggestedName: string; out FileName: string): Boolean;
+    function PromptExportHtml(const SuggestedName: string; out FileName: string): Boolean;
+    function ConfirmClose: TPadCloseChoice;
+    function ConfirmCloseDocument(const DocName: string): TPadCloseChoice;
+    function ConfirmReload: Boolean;
+    procedure ShowOpenError(const FileName, ErrorMessage: string);
+    procedure CopyHtmlToClipboard(const Fragment: string);
+    procedure CloseApplication;
     procedure BuildToolbar;
     function ResolveIconFontName: string;
     function AddIconButton(const Glyph: string; const Hint: string; const Handler: TNotifyEvent): TRectangle;
@@ -198,7 +177,7 @@ type
     procedure HideHint;
     procedure BuildPalette;
     procedure BuildCommandRegistry;
-    procedure RegisterStaticCommands;
+    function BuildCommandActions: TPadCommandActions;
     procedure RestoreSession;
     function HandleFormKey(const Key: Word; const Shift: TShiftState): Boolean;
     procedure SetViewMode(const Mode: TPadViewMode);
@@ -227,8 +206,6 @@ type
     procedure OpenPath(const FileName: string);
     procedure HandleSaveClick(Sender: TObject);
     procedure HandleSaveAsClick(Sender: TObject);
-    function TrySaveActive: Boolean;
-    procedure SaveToFile(const FileName: string);
     procedure CloseActiveDocument;
     procedure CloseDocumentAt(const Index: Integer);
     procedure HandleExportClick(Sender: TObject);
@@ -248,8 +225,6 @@ type
     procedure HandlePreviewLinkClick(const Sender: TObject; const Url: string);
     procedure HandleTocChange(Sender: TObject);
     procedure HandleTick(Sender: TObject);
-    procedure HandleFileChanged(const Document: IPadDocument);
-    procedure ReloadDocument(const Document: IPadDocument);
     function GetEditorText: string;
     procedure SetEditorText(const Value: string);
     function GetEditorCaret: Integer;
@@ -261,14 +236,15 @@ type
     function SaveEditState: IMarkdownEditorState;
     procedure LoadEditState(const State: IMarkdownEditorState);
     procedure FlushPreview;
+    procedure EditorFindNext(const Needle: string);
+    function EditorFindMatchCount(const Needle: string): Integer;
+    procedure PreviewFindText(const Needle: string);
     procedure BeginSwap;
     procedure EndSwap;
     procedure SwitchToDocument(const Index: Integer);
     procedure RebuildTabs;
     procedure RebuildSyncAndToc;
     procedure UpdateActiveTocEntry(const SourceLine: Integer);
-    procedure UpdateStatusBar;
-    procedure UpdateTitle;
     procedure ExecuteFind;
     procedure ApplyTheme;
     procedure ApplyChromeColors;
@@ -309,7 +285,6 @@ uses
   Markdown4D.Ast.Interfaces,
   MarkdownPad.Text,
   MarkdownPad.Outline,
-  MarkdownPad.CommandSet,
   MarkdownPad.SessionSync,
   MarkdownPad.Workspace,
   MarkdownPad.HtmlExport,
@@ -332,8 +307,7 @@ begin
   FLightTheme := TMarkdownTheme.CreateLight;
   FDarkTheme := TMarkdownTheme.CreateDark;
 
-  FWorkspace := TPadWorkspace.Create;
-  FWatcher := TPadFileWatcher.Create(FWorkspace, HandleFileChanged);
+  FController := TPadController.Create(Self, Self, SessionFileName);
 
   FOpenDialog := TOpenDialog.Create(Self);
   FOpenDialog.Filter := MarkdownFilter;
@@ -363,6 +337,9 @@ begin
   FViewMode := TPadViewMode.Split;
   FSplitEditorWidth := (InitialClientWidth - TocPanelWidth) / 2;
 
+  FDarkThemeActive := FController.Session.DarkTheme;
+  ApplyTheme;
+
   RestoreSession;
 
   FMapDirty := True;
@@ -377,9 +354,7 @@ begin
 
   inherited Destroy;
 
-  FWatcher.Free;
-  FCommands.Free;
-  FSession.Free;
+  FController.Free;
   FDarkTheme.Free;
   FLightTheme.Free;
 end;
@@ -874,65 +849,43 @@ end;
 
 procedure TMarkdownPadFMXForm.BuildCommandRegistry;
 begin
-  FCommands := TPadCommandRegistry.Create;
-
-  RegisterStaticCommands;
+  FController.InitCommandRegistry(BuildCommandActions);
 end;
 
-procedure TMarkdownPadFMXForm.RegisterStaticCommands;
-var
-  Actions: TPadCommandActions;
+function TMarkdownPadFMXForm.BuildCommandActions: TPadCommandActions;
 begin
-  Actions.NewDocument := procedure begin HandleNewClick(nil); end;
-  Actions.OpenDocument := procedure begin HandleOpenClick(nil); end;
-  Actions.Save := procedure begin HandleSaveClick(nil); end;
-  Actions.SaveAs := procedure begin HandleSaveAsClick(nil); end;
-  Actions.CloseDocument := procedure begin CloseActiveDocument; end;
-  Actions.NextTab :=
+  Result.NewDocument := procedure begin HandleNewClick(nil); end;
+  Result.OpenDocument := procedure begin HandleOpenClick(nil); end;
+  Result.Save := procedure begin HandleSaveClick(nil); end;
+  Result.SaveAs := procedure begin HandleSaveAsClick(nil); end;
+  Result.CloseDocument := procedure begin CloseActiveDocument; end;
+  Result.NextTab :=
     procedure
     begin
       FWorkspace.ActivateNext;
       SwitchToDocument(FWorkspace.ActiveIndex);
     end;
-  Actions.ExportHtml := procedure begin DoExportHtml; end;
-  Actions.CopyHtml := procedure begin DoCopyHtml; end;
-  Actions.ViewEditorOnly := procedure begin SetViewMode(TPadViewMode.EditorOnly); end;
-  Actions.ViewSplit := procedure begin SetViewMode(TPadViewMode.Split); end;
-  Actions.ViewPreviewOnly := procedure begin SetViewMode(TPadViewMode.PreviewOnly); end;
-  Actions.ToggleZen := procedure begin ToggleZen; end;
-  Actions.ToggleTheme := procedure begin HandleThemeClick(nil); end;
-  Actions.ToggleToc := procedure begin HandleTocClick(nil); end;
-  Actions.ShowFind := procedure begin ShowFindBar; end;
-  Actions.FindInPreview := procedure begin ExecuteFind; end;
-  Actions.ExecuteFormat :=
+  Result.ExportHtml := procedure begin DoExportHtml; end;
+  Result.CopyHtml := procedure begin DoCopyHtml; end;
+  Result.ViewEditorOnly := procedure begin SetViewMode(TPadViewMode.EditorOnly); end;
+  Result.ViewSplit := procedure begin SetViewMode(TPadViewMode.Split); end;
+  Result.ViewPreviewOnly := procedure begin SetViewMode(TPadViewMode.PreviewOnly); end;
+  Result.ToggleZen := procedure begin ToggleZen; end;
+  Result.ToggleTheme := procedure begin HandleThemeClick(nil); end;
+  Result.ToggleToc := procedure begin HandleTocClick(nil); end;
+  Result.ShowFind := procedure begin ShowFindBar; end;
+  Result.FindInPreview := procedure begin ExecuteFind; end;
+  Result.ExecuteFormat :=
     procedure(const Command: TEditorCommand)
     begin
       FEditor.ExecuteCommand(Command);
       FEditor.SetFocus;
     end;
-
-  RegisterStaticPadCommands(FCommands, Actions);
 end;
 
 procedure TMarkdownPadFMXForm.RestoreSession;
 begin
-  FSession := TPadSession.Create(TPadSession.ResolvePath(SessionFileName));
-  FSession.Load;
-
-  FDarkThemeActive := FSession.DarkTheme;
-  ApplyTheme;
-
-  FViewMode := FSession.ViewMode;
-  ApplyViewMode;
-
-  if not TPadSessionSync.RestoreOpenFiles(FWorkspace, FSession) then
-  begin
-    const Document = FWorkspace.NewDocument;
-    Document.Text := BuildSampleMarkdown;
-  end;
-
-  RebuildTabs;
-  SwitchToDocument(FWorkspace.ActiveIndex);
+  FController.RestoreSession;
 end;
 
 procedure TMarkdownPadFMXForm.KeyDown(var Key: Word; var KeyChar: WideChar; Shift: TShiftState);
@@ -1099,28 +1052,7 @@ begin
   if FZenActive then
     ExitZen;
 
-  for var Index := 0 to FWorkspace.Count - 1 do
-  begin
-    const Document = FWorkspace.Documents[Index];
-    if not Document.Modified then
-      Continue;
-
-    SwitchToDocument(Index);
-
-    const Prompt = Format(CloseDocumentPromptFormat, [Document.DisplayName]);
-    const Answer = TDialogServiceSync.MessageDialog(Prompt, TMsgDlgType.mtConfirmation,
-      [TMsgDlgBtn.mbYes, TMsgDlgBtn.mbNo, TMsgDlgBtn.mbCancel], TMsgDlgBtn.mbCancel, 0);
-
-    if Answer = mrCancel then
-      Exit(False);
-
-    if (Answer = mrYes) and not TrySaveActive then
-      Exit(False);
-
-    Document.Modified := False;
-  end;
-
-  Result := True;
+  Result := FController.QueryClose;
 end;
 
 procedure TMarkdownPadFMXForm.Resize;
@@ -1197,38 +1129,6 @@ begin
   FEditor.SetFocus;
 end;
 
-procedure TMarkdownPadFMXForm.FindInEditor;
-begin
-  const Needle = FEditorFindEdit.Text;
-  if Needle = '' then
-  begin
-    UpdateFindCount;
-    Exit;
-  end;
-
-  FEditor.FindNext(Needle);
-
-  UpdateFindCount;
-end;
-
-procedure TMarkdownPadFMXForm.UpdateFindCount;
-begin
-  const Needle = FEditorFindEdit.Text;
-  if Needle = '' then
-  begin
-    FEditorFindCount.Text := EmptyFindCaption;
-    Exit;
-  end;
-
-  const N = FEditor.FindMatchCount(Needle);
-
-  if N = 0 then
-    FEditorFindCount.Text := NoMatchCaption
-  else if N = 1 then
-    FEditorFindCount.Text := SingleMatchCaption
-  else
-    FEditorFindCount.Text := Format(MatchCountFormat, [N]);
-end;
 
 procedure TMarkdownPadFMXForm.HandleEditorFindKeyDown(Sender: TObject; var Key: Word; var KeyChar: WideChar;
   Shift: TShiftState);
@@ -1255,18 +1155,7 @@ end;
 
 procedure TMarkdownPadFMXForm.ShowPalette;
 begin
-  FCommands.Clear;
-  RegisterStaticCommands;
-
-  for var FileName in FSession.RecentFiles do
-  begin
-    const Path = FileName;
-    FCommands.Register(Path, CatRecent, '',
-      procedure
-      begin
-        OpenPath(Path);
-      end);
-  end;
+  FController.RebuildPaletteCommands;
 
   FPaletteEdit.Text := '';
 
@@ -1289,7 +1178,7 @@ end;
 
 procedure TMarkdownPadFMXForm.RefreshPaletteList;
 begin
-  FPaletteMatches := FCommands.Match(FPaletteEdit.Text);
+  FController.RefreshMatches(FPaletteEdit.Text);
 
   FPaletteList.BeginUpdate;
   try
@@ -1344,15 +1233,12 @@ end;
 procedure TMarkdownPadFMXForm.ExecuteSelectedCommand;
 begin
   const Index = FPaletteList.ItemIndex;
-  if (Index < 0) or (Index > High(FPaletteMatches)) then
+  if (Index < 0) or (Index >= FController.PaletteMatchCount) then
     Exit;
-
-  const Action = FPaletteMatches[Index].Command.Action;
 
   ClosePalette;
 
-  if Assigned(Action) then
-    Action();
+  FController.InvokePaletteCommand(Index);
 end;
 
 procedure TMarkdownPadFMXForm.HandlePaletteChange(Sender: TObject);
@@ -1460,16 +1346,12 @@ end;
 
 procedure TMarkdownPadFMXForm.HandleNewClick(Sender: TObject);
 begin
-  FWorkspace.NewDocument;
-
-  RebuildTabs;
-  SwitchToDocument(FWorkspace.ActiveIndex);
+  FController.NewDocument;
 end;
 
 procedure TMarkdownPadFMXForm.HandleOpenClick(Sender: TObject);
 begin
-  if FOpenDialog.Execute then
-    OpenPath(FOpenDialog.FileName);
+  FController.OpenViaDialog;
 end;
 
 procedure TMarkdownPadFMXForm.HandleRecentClick(Sender: TObject);
@@ -1509,119 +1391,27 @@ end;
 
 procedure TMarkdownPadFMXForm.OpenPath(const FileName: string);
 begin
-  if not TFile.Exists(FileName) then
-    Exit;
-
-  var Document: IPadDocument;
-  try
-    Document := FWorkspace.OpenFile(FileName);
-  except
-    on E: Exception do
-    begin
-      TDialogServiceSync.MessageDialog(Format(OpenErrorFormat, [FileName]), TMsgDlgType.mtError,
-        [TMsgDlgBtn.mbOK], TMsgDlgBtn.mbOK, 0);
-      Exit;
-    end;
-  end;
-
-  FSession.AddRecentFile(FileName);
-  FWatcher.Reset(Document);
-
-  RebuildTabs;
-  SwitchToDocument(FWorkspace.ActiveIndex);
+  FController.OpenPath(FileName);
 end;
 
 procedure TMarkdownPadFMXForm.HandleSaveClick(Sender: TObject);
 begin
-  TrySaveActive;
+  FController.Save;
 end;
 
 procedure TMarkdownPadFMXForm.HandleSaveAsClick(Sender: TObject);
 begin
-  if FActiveDoc = nil then
-    Exit;
-
-  if not FActiveDoc.IsUntitled then
-    FSaveDialog.FileName := FActiveDoc.FileName;
-
-  if FSaveDialog.Execute then
-    SaveToFile(FSaveDialog.FileName);
-end;
-
-function TMarkdownPadFMXForm.TrySaveActive: Boolean;
-begin
-  if FActiveDoc = nil then
-    Exit(True);
-
-  if FActiveDoc.IsUntitled then
-  begin
-    if not FSaveDialog.Execute then
-      Exit(False);
-
-    SaveToFile(FSaveDialog.FileName);
-  end
-  else
-    SaveToFile(FActiveDoc.FileName);
-
-  Result := True;
-end;
-
-procedure TMarkdownPadFMXForm.SaveToFile(const FileName: string);
-begin
-  FActiveDoc.Text := FEditor.Text;
-
-  TFile.WriteAllText(FileName, FEditor.Text);
-
-  FActiveDoc.FileName := FileName;
-  FActiveDoc.Modified := False;
-  FWatcher.Reset(FActiveDoc);
-
-  FSession.AddRecentFile(FileName);
-
-  RebuildTabs;
-  UpdateTitle;
+  FController.SaveAs;
 end;
 
 procedure TMarkdownPadFMXForm.CloseActiveDocument;
 begin
-  CloseDocumentAt(FWorkspace.ActiveIndex);
+  FController.CloseActiveDocument;
 end;
 
 procedure TMarkdownPadFMXForm.CloseDocumentAt(const Index: Integer);
 begin
-  if (Index < 0) or (Index >= FWorkspace.Count) then
-    Exit;
-
-  if Index <> FWorkspace.ActiveIndex then
-    SwitchToDocument(Index);
-
-  if FActiveDoc = nil then
-    Exit;
-
-  if FActiveDoc.Modified then
-  begin
-    const Answer = TDialogServiceSync.MessageDialog(CloseUnsavedPrompt, TMsgDlgType.mtConfirmation,
-      [TMsgDlgBtn.mbYes, TMsgDlgBtn.mbNo, TMsgDlgBtn.mbCancel], TMsgDlgBtn.mbCancel, 0);
-
-    if Answer = mrCancel then
-      Exit;
-
-    if (Answer = mrYes) and not TrySaveActive then
-      Exit;
-  end;
-
-  const ClosingIndex = FWorkspace.ActiveIndex;
-  FActiveDoc := nil;
-  FWorkspace.CloseDocument(ClosingIndex);
-
-  if FWorkspace.Count = 0 then
-  begin
-    Close;
-    Exit;
-  end;
-
-  RebuildTabs;
-  SwitchToDocument(FWorkspace.ActiveIndex);
+  FController.CloseDocumentAt(Index);
 end;
 
 procedure TMarkdownPadFMXForm.HandleExportClick(Sender: TObject);
@@ -1631,21 +1421,17 @@ end;
 
 procedure TMarkdownPadFMXForm.DoExportHtml;
 begin
-  if FActiveDoc <> nil then
-    FActiveDoc.Text := FEditor.Text;
+  FController.ExportHtml;
+end;
 
-  var Title := UntitledName;
-  if FActiveDoc <> nil then
-    Title := FActiveDoc.DisplayName;
+function TMarkdownPadFMXForm.PromptExportHtml(const SuggestedName: string; out FileName: string): Boolean;
+begin
+  if SuggestedName <> '' then
+    FHtmlSaveDialog.FileName := SuggestedName;
 
-  FHtmlSaveDialog.FileName := TPath.ChangeExtension(Title, '.' + HtmlExtension);
-
-  if not FHtmlSaveDialog.Execute then
-    Exit;
-
-  const Html = TMarkdownHtmlExport.BuildDocument(FEditor.Text, Title, FDarkThemeActive);
-
-  TFile.WriteAllText(FHtmlSaveDialog.FileName, Html, TEncoding.UTF8);
+  Result := FHtmlSaveDialog.Execute;
+  if Result then
+    FileName := FHtmlSaveDialog.FileName;
 end;
 
 procedure TMarkdownPadFMXForm.HandleCopyHtmlClick(Sender: TObject);
@@ -1655,8 +1441,11 @@ end;
 
 procedure TMarkdownPadFMXForm.DoCopyHtml;
 begin
-  const Fragment = TMarkdown.ToHtml(FEditor.Text, TMarkdownDialect.Gfm);
+  FController.CopyHtml;
+end;
 
+procedure TMarkdownPadFMXForm.CopyHtmlToClipboard(const Fragment: string);
+begin
   var Clip: IFMXClipboardService;
   if TPlatformServices.Current.SupportsPlatformService(IFMXClipboardService, Clip) then
     Clip.SetClipboard(Fragment);
@@ -1717,20 +1506,7 @@ end;
 
 procedure TMarkdownPadFMXForm.HandleEditorChange(Sender: TObject);
 begin
-  if FSwapping then
-    Exit;
-
-  const WasModified = (FActiveDoc <> nil) and FActiveDoc.Modified;
-
-  if FActiveDoc <> nil then
-    FActiveDoc.Modified := True;
-
-  FMapDirty := True;
-
-  if not WasModified then
-    RebuildTabs;
-
-  UpdateTitle;
+  FController.NotifyEditorChanged;
 end;
 
 procedure TMarkdownPadFMXForm.HandleSyncScroll(Sender: TObject; const SourceLine: Integer);
@@ -1754,16 +1530,16 @@ begin
     Exit;
 
   const Index = FTocList.ItemIndex;
-  if (Index < 0) or (Index > High(FTocEntries)) then
+  if (Index < 0) or (Index >= FController.TocEntryCount) then
     Exit;
 
   if FMapDirty then
     RebuildSyncAndToc;
 
-  if (Index < 0) or (Index > High(FTocEntries)) then
+  if (Index < 0) or (Index >= FController.TocEntryCount) then
     Exit;
 
-  const SourceLine = FTocEntries[Index].SourceLine - 1;
+  const SourceLine = FController.TocSourceLine(Index);
 
   // Scrolling the editor drives the preview through the linked SyncScroll; guard
   // the outline so the resulting sync callback does not fight the selection.
@@ -1781,59 +1557,7 @@ end;
 
 procedure TMarkdownPadFMXForm.HandleTick(Sender: TObject);
 begin
-  if FMapDirty then
-    RebuildSyncAndToc;
-
-  UpdateStatusBar;
-
-  FWatcher.Poll;
-end;
-
-procedure TMarkdownPadFMXForm.HandleFileChanged(const Document: IPadDocument);
-begin
-  if Document.Modified then
-  begin
-    const Answer = TDialogServiceSync.MessageDialog(ReloadPrompt, TMsgDlgType.mtConfirmation,
-      [TMsgDlgBtn.mbYes, TMsgDlgBtn.mbNo], TMsgDlgBtn.mbNo, 0);
-
-    if Answer <> mrYes then
-      Exit;
-  end;
-
-  ReloadDocument(Document);
-end;
-
-procedure TMarkdownPadFMXForm.ReloadDocument(const Document: IPadDocument);
-begin
-  var NewText: string;
-  try
-    NewText := TFile.ReadAllText(Document.FileName);
-  except
-    on E: Exception do
-    begin
-      Document.DiskTimestampUtc := 0;
-      Exit;
-    end;
-  end;
-
-  Document.Text := NewText;
-  Document.Modified := False;
-
-  if Document = FActiveDoc then
-  begin
-    FSwapping := True;
-    try
-      FEditor.Text := NewText;
-      FEditor.FlushPreview;
-    finally
-      FSwapping := False;
-    end;
-
-    FMapDirty := True;
-  end;
-
-  RebuildTabs;
-  UpdateTitle;
+  FController.Tick;
 end;
 
 function TMarkdownPadFMXForm.GetEditorText: string;
@@ -1903,19 +1627,7 @@ end;
 
 procedure TMarkdownPadFMXForm.SwitchToDocument(const Index: Integer);
 begin
-  if FSwapping then
-    Exit;
-
-  FActiveDoc := TPadDocumentSwitch.Execute(FWorkspace, Self, FActiveDoc, Index);
-
-  if FActiveDoc = nil then
-    Exit;
-
-  FLastCaret := -1;
-  FMapDirty := True;
-
-  RebuildTabs;
-  UpdateTitle;
+  FController.SwitchToDocument(Index);
 end;
 
 procedure TMarkdownPadFMXForm.RebuildTabs;
@@ -1929,19 +1641,48 @@ end;
 
 procedure TMarkdownPadFMXForm.RebuildSyncAndToc;
 begin
-  FMapDirty := False;
+  FController.RebuildSyncAndToc;
+end;
 
-  const Document = TMarkdown.Parse(FEditor.Text, TMarkdownDialect.Gfm);
+procedure TMarkdownPadFMXForm.UpdateActiveTocEntry(const SourceLine: Integer);
+begin
+  FController.UpdateActiveTocEntry(SourceLine);
+end;
 
-  const Outline = TPadOutlineBuilder.Build(TMarkdownToc.FromDocument(Document));
-  FTocEntries := Outline.Entries;
+procedure TMarkdownPadFMXForm.ExecuteFind;
+begin
+  FController.ExecuteFind;
+end;
 
+procedure TMarkdownPadFMXForm.FindInEditor;
+begin
+  FController.FindInEditor;
+end;
+
+procedure TMarkdownPadFMXForm.UpdateFindCount;
+begin
+  FController.UpdateFindCount;
+end;
+
+procedure TMarkdownPadFMXForm.SetDocumentTitle(const Name: string);
+begin
+  Caption := Format(TitleFormat, [WindowCaption, Name]);
+end;
+
+procedure TMarkdownPadFMXForm.SetStatus(const PositionText, WordsText: string);
+begin
+  FStatusPositionLabel.Text := PositionText;
+  FStatusWordsLabel.Text := WordsText;
+end;
+
+procedure TMarkdownPadFMXForm.SetTocCaptions(const Captions: TArray<string>);
+begin
   FTocFollowing := True;
   FTocList.Items.BeginUpdate;
   try
     FTocList.Items.Clear;
 
-    for var Caption in Outline.Captions do
+    for var Caption in Captions do
       FTocList.Items.Add(Caption);
   finally
     FTocList.Items.EndUpdate;
@@ -1951,54 +1692,66 @@ begin
   ApplyTocItemColors;
 end;
 
-procedure TMarkdownPadFMXForm.UpdateActiveTocEntry(const SourceLine: Integer);
+procedure TMarkdownPadFMXForm.SetActiveTocIndex(const Index: Integer);
 begin
-  const Best = TPadOutlineBuilder.ActiveIndex(FTocEntries, SourceLine);
-
-  if Best = FTocList.ItemIndex then
+  if Index = FTocList.ItemIndex then
     Exit;
 
   FTocFollowing := True;
   try
-    FTocList.ItemIndex := Best;
+    FTocList.ItemIndex := Index;
   finally
     FTocFollowing := False;
   end;
 end;
 
-procedure TMarkdownPadFMXForm.UpdateStatusBar;
+function TMarkdownPadFMXForm.EditorFindNeedle: string;
 begin
-  const Caret = FEditor.CaretPosition;
-  if Caret = FLastCaret then
-    Exit;
-
-  FLastCaret := Caret;
-
-  var Line, Column: Integer;
-  TPadText.ComputeLineColumn(FEditor.Text, Caret, Line, Column);
-  FStatusPositionLabel.Text := Format(StatusPositionFormat, [Line, Column]);
-  FStatusWordsLabel.Text := Format(StatusWordsFormat, [TPadText.CountWords(FEditor.Text)]);
+  Result := FEditorFindEdit.Text;
 end;
 
-procedure TMarkdownPadFMXForm.UpdateTitle;
+function TMarkdownPadFMXForm.PreviewFindNeedle: string;
 begin
-  var Name := UntitledName;
-  if FActiveDoc <> nil then
-    Name := FActiveDoc.DisplayName;
-
-  if (FActiveDoc <> nil) and FActiveDoc.Modified then
-    Name := Name + ModifiedMarker;
-
-  Caption := Format(TitleFormat, [WindowCaption, Name]);
+  Result := FFindEdit.Text;
 end;
 
-procedure TMarkdownPadFMXForm.ExecuteFind;
+procedure TMarkdownPadFMXForm.SetFindCount(const Value: string);
 begin
-  const Needle = FFindEdit.Text;
-  if Needle = '' then
-    Exit;
+  FEditorFindCount.Text := Value;
+end;
 
+procedure TMarkdownPadFMXForm.EditorFindNext(const Needle: string);
+begin
+  FEditor.FindNext(Needle);
+end;
+
+function TMarkdownPadFMXForm.EditorFindMatchCount(const Needle: string): Integer;
+begin
+  Result := FEditor.FindMatchCount(Needle);
+end;
+
+procedure TMarkdownPadFMXForm.PreviewFindText(const Needle: string);
+begin
   FPreview.FindText(Needle);
+end;
+
+function TMarkdownPadFMXForm.ConfirmCloseDocument(const DocName: string): TPadCloseChoice;
+begin
+  const Answer = TDialogServiceSync.MessageDialog(Format(CloseDocumentPromptFormat, [DocName]),
+    TMsgDlgType.mtConfirmation, [TMsgDlgBtn.mbYes, TMsgDlgBtn.mbNo, TMsgDlgBtn.mbCancel], TMsgDlgBtn.mbCancel, 0);
+
+  if Answer = mrCancel then
+    Result := TPadCloseChoice.Cancel
+  else if Answer = mrYes then
+    Result := TPadCloseChoice.Save
+  else
+    Result := TPadCloseChoice.Discard;
+end;
+
+function TMarkdownPadFMXForm.ConfirmReload: Boolean;
+begin
+  Result := TDialogServiceSync.MessageDialog(ReloadPrompt, TMsgDlgType.mtConfirmation,
+    [TMsgDlgBtn.mbYes, TMsgDlgBtn.mbNo], TMsgDlgBtn.mbNo, 0) = mrYes;
 end;
 
 procedure TMarkdownPadFMXForm.ApplyTheme;
@@ -2129,21 +1882,107 @@ end;
 
 procedure TMarkdownPadFMXForm.SaveSession;
 begin
-  if FSession = nil then
-    Exit;
+  FController.SaveSession;
+end;
 
-  var FilteredActive: Integer;
-  const Titled = TPadSessionSync.CollectOpenFiles(FWorkspace, FilteredActive);
+function TMarkdownPadFMXForm.GetWorkspace: IPadWorkspace;
+begin
+  Result := FController.Workspace;
+end;
 
-  FSession.SetOpenFiles(Titled, FilteredActive);
-  FSession.DarkTheme := FDarkThemeActive;
+function TMarkdownPadFMXForm.GetSession: TPadSession;
+begin
+  Result := FController.Session;
+end;
 
+function TMarkdownPadFMXForm.GetMapDirty: Boolean;
+begin
+  Result := FController.MapDirty;
+end;
+
+procedure TMarkdownPadFMXForm.SetMapDirty(const Value: Boolean);
+begin
+  FController.MapDirty := Value;
+end;
+
+function TMarkdownPadFMXForm.GetSwapping: Boolean;
+begin
+  Result := FController.Swapping;
+end;
+
+procedure TMarkdownPadFMXForm.SetSwapping(const Value: Boolean);
+begin
+  FController.Swapping := Value;
+end;
+
+function TMarkdownPadFMXForm.GetPaletteMatches: TArray<TPadCommandMatch>;
+begin
+  Result := FController.PaletteMatches;
+end;
+
+function TMarkdownPadFMXForm.SampleMarkdown: string;
+begin
+  Result := BuildSampleMarkdown;
+end;
+
+function TMarkdownPadFMXForm.DarkThemeActive: Boolean;
+begin
+  Result := FDarkThemeActive;
+end;
+
+function TMarkdownPadFMXForm.EffectiveViewMode: TPadViewMode;
+begin
   if FZenActive then
-    FSession.ViewMode := FPreZenViewMode
+    Result := FPreZenViewMode
   else
-    FSession.ViewMode := FViewMode;
+    Result := FViewMode;
+end;
 
-  FSession.Save;
+procedure TMarkdownPadFMXForm.ApplyRestoredViewMode(const Mode: TPadViewMode);
+begin
+  FViewMode := Mode;
+  ApplyViewMode;
+end;
+
+function TMarkdownPadFMXForm.PromptOpenFile(out FileName: string): Boolean;
+begin
+  Result := FOpenDialog.Execute;
+  if Result then
+    FileName := FOpenDialog.FileName;
+end;
+
+function TMarkdownPadFMXForm.PromptSaveFile(const SuggestedName: string; out FileName: string): Boolean;
+begin
+  if SuggestedName <> '' then
+    FSaveDialog.FileName := SuggestedName;
+
+  Result := FSaveDialog.Execute;
+  if Result then
+    FileName := FSaveDialog.FileName;
+end;
+
+function TMarkdownPadFMXForm.ConfirmClose: TPadCloseChoice;
+begin
+  const Answer = TDialogServiceSync.MessageDialog(CloseUnsavedPrompt, TMsgDlgType.mtConfirmation,
+    [TMsgDlgBtn.mbYes, TMsgDlgBtn.mbNo, TMsgDlgBtn.mbCancel], TMsgDlgBtn.mbCancel, 0);
+
+  if Answer = mrCancel then
+    Result := TPadCloseChoice.Cancel
+  else if Answer = mrYes then
+    Result := TPadCloseChoice.Save
+  else
+    Result := TPadCloseChoice.Discard;
+end;
+
+procedure TMarkdownPadFMXForm.ShowOpenError(const FileName, ErrorMessage: string);
+begin
+  TDialogServiceSync.MessageDialog(Format(OpenErrorFormat, [FileName]), TMsgDlgType.mtError,
+    [TMsgDlgBtn.mbOK], TMsgDlgBtn.mbOK, 0);
+end;
+
+procedure TMarkdownPadFMXForm.CloseApplication;
+begin
+  Close;
 end;
 
 class function TMarkdownPadFMXForm.BuildSampleMarkdown: string;

--- a/Examples/MarkdownPadFMX/MarkdownPadFMX.dpr
+++ b/Examples/MarkdownPadFMX/MarkdownPadFMX.dpr
@@ -18,7 +18,10 @@ uses
   MarkdownPadFMX.Main in 'MarkdownPadFMX.Main.pas',
   MarkdownPad.Defines in '..\Shared\MarkdownPad.Defines.pas',
   MarkdownPad.Text in '..\Shared\MarkdownPad.Text.pas',
-  MarkdownPad.Outline in '..\Shared\MarkdownPad.Outline.pas';
+  MarkdownPad.Outline in '..\Shared\MarkdownPad.Outline.pas',
+  MarkdownPadFMX.Defines in 'MarkdownPadFMX.Defines.pas',
+  MarkdownPad.Shell in '..\Shared\MarkdownPad.Shell.pas',
+  MarkdownPad.Controller in '..\Shared\MarkdownPad.Controller.pas';
 
 {$R *.res}
 

--- a/Examples/MarkdownPadFMX/MarkdownPadFMX.dproj
+++ b/Examples/MarkdownPadFMX/MarkdownPadFMX.dproj
@@ -101,7 +101,6 @@ $(PostBuildEvent)]]></PostBuildEvent>
         </DelphiCompile>
         <DCCReference Include="..\Shared\MarkdownPad.Workspace.Interfaces.pas"/>
         <DCCReference Include="..\Shared\MarkdownPad.Workspace.pas"/>
-        <DCCReference Include="..\Shared\MarkdownPad.EditorView.pas"/>
         <DCCReference Include="..\Shared\MarkdownPad.Session.pas"/>
         <DCCReference Include="..\Shared\MarkdownPad.Commands.pas"/>
         <DCCReference Include="..\Shared\MarkdownPad.TabStrip.Layout.pas"/>
@@ -116,6 +115,9 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <DCCReference Include="..\Shared\MarkdownPad.Defines.pas"/>
         <DCCReference Include="..\Shared\MarkdownPad.Text.pas"/>
         <DCCReference Include="..\Shared\MarkdownPad.Outline.pas"/>
+        <DCCReference Include="MarkdownPadFMX.Defines.pas"/>
+        <DCCReference Include="..\Shared\MarkdownPad.Shell.pas"/>
+        <DCCReference Include="..\Shared\MarkdownPad.Controller.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
@@ -1125,7 +1127,7 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <PreBuildEventIgnoreExitCode>False</PreBuildEventIgnoreExitCode>
         <PreLinkEvent/>
         <PreLinkEventIgnoreExitCode>False</PreLinkEventIgnoreExitCode>
-        <PostBuildEvent>copy /Y &quot;$(BDS)\bin\sk4d.dll&quot; &quot;$(MSBuildProjectDirectory)\$(Platform)\$(Config)\&quot;</PostBuildEvent>
+        <PostBuildEvent>copy /Y &quot;$(BDS)\bin\sk4d.dll&quot; &quot;$(MSBuildProjectDirectory)\$(Platform)\$(Config)\&quot;</PostBuildEvent>
         <PostBuildEventIgnoreExitCode>False</PostBuildEventIgnoreExitCode>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Debug' And '$(Platform)'=='Win64'">
@@ -1133,7 +1135,7 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <PreBuildEventIgnoreExitCode>False</PreBuildEventIgnoreExitCode>
         <PreLinkEvent/>
         <PreLinkEventIgnoreExitCode>False</PreLinkEventIgnoreExitCode>
-        <PostBuildEvent>copy /Y &quot;$(BDS)\bin\sk4d.dll&quot; &quot;$(MSBuildProjectDirectory)\$(Platform)\$(Config)\&quot;</PostBuildEvent>
+        <PostBuildEvent>copy /Y &quot;$(BDS)\bin\sk4d.dll&quot; &quot;$(MSBuildProjectDirectory)\$(Platform)\$(Config)\&quot;</PostBuildEvent>
         <PostBuildEventIgnoreExitCode>False</PostBuildEventIgnoreExitCode>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Release' And '$(Platform)'=='Win32'">
@@ -1141,7 +1143,7 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <PreBuildEventIgnoreExitCode>False</PreBuildEventIgnoreExitCode>
         <PreLinkEvent/>
         <PreLinkEventIgnoreExitCode>False</PreLinkEventIgnoreExitCode>
-        <PostBuildEvent>copy /Y &quot;$(BDS)\bin\sk4d.dll&quot; &quot;$(MSBuildProjectDirectory)\$(Platform)\$(Config)\&quot;</PostBuildEvent>
+        <PostBuildEvent>copy /Y &quot;$(BDS)\bin\sk4d.dll&quot; &quot;$(MSBuildProjectDirectory)\$(Platform)\$(Config)\&quot;</PostBuildEvent>
         <PostBuildEventIgnoreExitCode>False</PostBuildEventIgnoreExitCode>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Release' And '$(Platform)'=='Win64'">
@@ -1149,7 +1151,7 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <PreBuildEventIgnoreExitCode>False</PreBuildEventIgnoreExitCode>
         <PreLinkEvent/>
         <PreLinkEventIgnoreExitCode>False</PreLinkEventIgnoreExitCode>
-        <PostBuildEvent>copy /Y &quot;$(BDS)\bin\sk4d.dll&quot; &quot;$(MSBuildProjectDirectory)\$(Platform)\$(Config)\&quot;</PostBuildEvent>
+        <PostBuildEvent>copy /Y &quot;$(BDS)\bin\sk4d.dll&quot; &quot;$(MSBuildProjectDirectory)\$(Platform)\$(Config)\&quot;</PostBuildEvent>
         <PostBuildEventIgnoreExitCode>False</PostBuildEventIgnoreExitCode>
     </PropertyGroup>
 </Project>

--- a/Examples/MarkdownPadVCL/MarkdownPadVCL.Defines.pas
+++ b/Examples/MarkdownPadVCL/MarkdownPadVCL.Defines.pas
@@ -1,0 +1,43 @@
+unit MarkdownPadVCL.Defines;
+
+// VCL-specific constants for the Markdown4D Pad demo. Values that are shared
+// verbatim with the FMX build live in MarkdownPad.Defines; only VCL-specific
+// values (custom title bar, DWM caption, TColor palette, per-build strings)
+// stay here.
+
+interface
+
+uses
+  System.UITypes;
+
+const
+  WindowCaption = 'Markdown4D Pad';
+  InitialClientWidth = 1200;
+  ToolbarHeight = 36;
+  TabsHeight = 30;
+  CaptionButtonsReserve = 160;
+  DwmCaptionColorAttribute = 35;
+  StatusBarHeight = 22;
+  StatusLabelWidth = 160;
+  StatusLabelLeftMargin = 8;
+  ButtonSpacing = 4;
+  IconGlyphSize = 14;
+  ToolbarLightColor = TColor($00F3F3F3);
+  ToolbarDarkColor = TColor($002D2D2D);
+  IconLightColor = TColor($00404040);
+  IconDarkColor = TColor($00D6D6D6);
+  SeparatorLightColor = TColor($00D0D0D0);
+  SeparatorDarkColor = TColor($00505050);
+  TabAccentColor = TColor($00C0742C);
+  TabActiveDarkColor = TColor($003F3F3F);
+  TabHoverLightColor = TColor($00EAEAEA);
+  TabHoverDarkColor = TColor($00383838);
+  ZenPadDarkColor = TColor($0017110D); // matches the dark theme editor/preview background ($0D1117)
+  SessionFileName = 'MarkdownPad.Vcl.json';
+  CloseUnsavedPrompt = 'Save changes before closing this document?';
+  ReloadPrompt = 'File changed on disk. Reload and lose your changes?';
+  PaletteTextMargin = 8;
+
+implementation
+
+end.

--- a/Examples/MarkdownPadVCL/MarkdownPadVCL.Main.pas
+++ b/Examples/MarkdownPadVCL/MarkdownPadVCL.Main.pas
@@ -29,11 +29,15 @@ uses
   MarkdownPad.EditorView,
   MarkdownPad.Session,
   MarkdownPad.Commands,
+  MarkdownPad.CommandSet,
   MarkdownPad.TabStrip,
-  MarkdownPad.FileWatcher;
+  MarkdownPad.FileWatcher,
+  MarkdownPad.Shell,
+  MarkdownPad.Controller,
+  MarkdownPadVCL.Defines;
 
 type
-  TMarkdownPadVCLForm = class(TForm, IPadEditorView)
+  TMarkdownPadVCLForm = class(TForm, IPadEditorView, IPadShell)
     pnlToolbar: TPanel;
     pnlFind: TPanel;
     pnlStatus: TPanel;
@@ -53,36 +57,6 @@ type
     edtEditorFind: TEdit;
     lblFindCount: TLabel;
   private
-    const
-      // Shared constants live in MarkdownPad.Defines; only VCL-specific values
-      // (custom title bar, DWM caption, TColor palette) stay here.
-      WindowCaption = 'Markdown4D Pad';
-      InitialClientWidth = 1200;
-      ToolbarHeight = 36;
-      TabsHeight = 30;
-      CaptionButtonsReserve = 160;
-      DwmCaptionColorAttribute = 35;
-      StatusBarHeight = 22;
-      StatusLabelWidth = 160;
-      StatusLabelLeftMargin = 8;
-      ButtonSpacing = 4;
-      IconGlyphSize = 14;
-      ToolbarLightColor = TColor($00F3F3F3);
-      ToolbarDarkColor = TColor($002D2D2D);
-      IconLightColor = TColor($00404040);
-      IconDarkColor = TColor($00D6D6D6);
-      SeparatorLightColor = TColor($00D0D0D0);
-      SeparatorDarkColor = TColor($00505050);
-      TabAccentColor = TColor($00C0742C);
-      TabActiveDarkColor = TColor($003F3F3F);
-      TabHoverLightColor = TColor($00EAEAEA);
-      TabHoverDarkColor = TColor($00383838);
-      ZenPadDarkColor = TColor($0017110D); // matches the dark theme editor/preview background ($0D1117)
-      SessionFileName = 'MarkdownPad.Vcl.json';
-      CloseUnsavedPrompt = 'Save changes before closing this document?';
-      ReloadPrompt = 'File changed on disk. Reload and lose your changes?';
-      PaletteTextMargin = 8;
-      RecentShortcut = '';
     var
       FIconFontName: string;
       FNewButton: TSpeedButton;
@@ -102,7 +76,6 @@ type
       FFindEdit: TEdit;
       FIconButtons: TArray<TSpeedButton>;
       FSeparators: TArray<TPanel>;
-      FTocEntries: TArray<IMarkdownTocEntry>;
       FLightTheme: TMarkdownTheme;
       FDarkTheme: TMarkdownTheme;
       FDarkThemeActive: Boolean;
@@ -110,26 +83,50 @@ type
       FTabStrip: TPadTabStrip;
       FUseCustomTitleBar: Boolean;
       FTitleBarColor: TColor;
-      FWorkspace: IPadWorkspace;
-      FActiveDoc: IPadDocument;
-      FSession: TPadSession;
-      FWatcher: TPadFileWatcher;
-      FMapDirty: Boolean;
-      FSwapping: Boolean;
-      FLastCaret: Integer;
+      FController: TPadController;
       FViewMode: TPadViewMode;
       FSplitEditorWidth: Integer;
       FPalette: TPanel;
       FPaletteEdit: TEdit;
       FPaletteList: TListBox;
-      FCommands: TPadCommandRegistry;
-      FPaletteMatches: TArray<TPadCommandMatch>;
       FZenActive: Boolean;
       FPreZenViewMode: TPadViewMode;
       FZenLeftPad: TPanel;
       FZenRightPad: TPanel;
       FZenTocWasVisible: Boolean;
       FZenFindWasVisible: Boolean;
+    // Read-through accessors to the controller-owned model state.
+    function GetWorkspace: IPadWorkspace;
+    function GetSession: TPadSession;
+    function GetMapDirty: Boolean;
+    procedure SetMapDirty(const Value: Boolean);
+    function GetSwapping: Boolean;
+    procedure SetSwapping(const Value: Boolean);
+    function GetPaletteMatches: TArray<TPadCommandMatch>;
+    property FWorkspace: IPadWorkspace read GetWorkspace;
+    property FSession: TPadSession read GetSession;
+    property FMapDirty: Boolean read GetMapDirty write SetMapDirty;
+    property FSwapping: Boolean read GetSwapping write SetSwapping;
+    property FPaletteMatches: TArray<TPadCommandMatch> read GetPaletteMatches;
+    procedure SetDocumentTitle(const Name: string);
+    procedure SetStatus(const PositionText, WordsText: string);
+    procedure SetTocCaptions(const Captions: TArray<string>);
+    procedure SetActiveTocIndex(const Index: Integer);
+    function EditorFindNeedle: string;
+    function PreviewFindNeedle: string;
+    procedure SetFindCount(const Value: string);
+    function SampleMarkdown: string;
+    function DarkThemeActive: Boolean;
+    function EffectiveViewMode: TPadViewMode;
+    procedure ApplyRestoredViewMode(const Mode: TPadViewMode);
+    function PromptOpenFile(out FileName: string): Boolean;
+    function PromptSaveFile(const SuggestedName: string; out FileName: string): Boolean;
+    function PromptExportHtml(const SuggestedName: string; out FileName: string): Boolean;
+    function ConfirmClose: TPadCloseChoice;
+    function ConfirmCloseDocument(const DocName: string): TPadCloseChoice;
+    function ConfirmReload: Boolean;
+    procedure ShowOpenError(const FileName, ErrorMessage: string);
+    procedure CloseApplication;
     procedure ConfigureControls;
     procedure BuildToolbar;
     function ResolveIconFontName: string;
@@ -172,7 +169,6 @@ type
     procedure HandlePreviewLinkClick(const Sender: TObject; const Url: string);
     procedure HandleTocListClick(Sender: TObject);
     procedure HandleTick(Sender: TObject);
-    procedure HandleFileChanged(const Document: IPadDocument);
     procedure OpenPath(const FileName: string);
     function GetEditorText: string;
     procedure SetEditorText(const Value: string);
@@ -185,25 +181,24 @@ type
     function SaveEditState: IMarkdownEditorState;
     procedure LoadEditState(const State: IMarkdownEditorState);
     procedure FlushPreview;
+    procedure EditorFindNext(const Needle: string);
+    function EditorFindMatchCount(const Needle: string): Integer;
+    procedure PreviewFindText(const Needle: string);
     procedure BeginSwap;
     procedure EndSwap;
     procedure SwitchToDocument(const Index: Integer);
     procedure CloseActiveDocument;
     procedure CloseDocumentAt(const Index: Integer);
-    function SaveActiveDocument: Boolean;
-    procedure SaveToFile(const FileName: string);
     procedure RestoreSession;
     procedure SaveSession;
     procedure RebuildTabs;
     procedure ApplyTheme;
     procedure RebuildSyncAndToc;
     procedure UpdateActiveTocEntry(const SourceLine: Integer);
-    procedure UpdateStatusBar;
-    procedure UpdateTitle;
     procedure ExecuteFind;
     procedure BuildPalette;
     procedure BuildCommandRegistry;
-    procedure RegisterStaticCommands;
+    function BuildCommandActions: TPadCommandActions;
     procedure SetViewMode(const Mode: TPadViewMode);
     procedure ApplyViewMode;
     procedure EnforceTopBarOrder;
@@ -254,7 +249,6 @@ uses
   Markdown4D.Extensions.Chart.BlockOverride,
   Markdown4D.Extensions.Mermaid.BlockOverride,
   MarkdownPad.Defines,
-  MarkdownPad.CommandSet,
   MarkdownPad.SessionSync,
   MarkdownPad.Text,
   MarkdownPad.Outline,
@@ -283,10 +277,7 @@ begin
   dlgSaveHtml.Filter := HtmlFilter;
   dlgSaveHtml.DefaultExt := HtmlExtension;
 
-  FWorkspace := TPadWorkspace.Create;
-  FSession := TPadSession.Create(TPadSession.ResolvePath(SessionFileName));
-  FSession.Load;
-  FWatcher := TPadFileWatcher.Create(FWorkspace, HandleFileChanged);
+  FController := TPadController.Create(Self, Self, SessionFileName);
 
   ConfigureControls;
   BuildToolbar;
@@ -322,9 +313,7 @@ begin
 
   inherited Destroy;
 
-  FCommands.Free;
-  FWatcher.Free;
-  FSession.Free;
+  FController.Free;
   FDarkTheme.Free;
   FLightTheme.Free;
 end;
@@ -704,68 +693,27 @@ begin
   if FZenActive then
     ExitZen;
 
-  for var Index := 0 to FWorkspace.Count - 1 do
-  begin
-    const Document = FWorkspace.Documents[Index];
-    if not Document.Modified then
-      Continue;
-
-    SwitchToDocument(Index);
-
-    const Prompt = Format(CloseDocumentPromptFormat, [Document.DisplayName]);
-    const Answer = MessageDlg(Prompt, mtConfirmation, [mbYes, mbNo, mbCancel], 0);
-
-    if Answer = mrCancel then
-    begin
-      CanClose := False;
-      Exit;
-    end;
-
-    if (Answer = mrYes) and not SaveActiveDocument then
-    begin
-      CanClose := False;
-      Exit;
-    end;
-
-    Document.Modified := False;
-  end;
-
-  CanClose := True;
+  CanClose := FController.QueryClose;
 end;
 
 procedure TMarkdownPadVCLForm.HandleNewClick(Sender: TObject);
 begin
-  FWorkspace.NewDocument;
-  SwitchToDocument(FWorkspace.ActiveIndex);
+  FController.NewDocument;
 end;
 
 procedure TMarkdownPadVCLForm.HandleOpenClick(Sender: TObject);
 begin
-  if dlgOpen.Execute then
-    OpenPath(dlgOpen.FileName);
+  FController.OpenViaDialog;
 end;
 
 procedure TMarkdownPadVCLForm.HandleSaveClick(Sender: TObject);
 begin
-  if FActiveDoc = nil then
-    Exit;
-
-  if FActiveDoc.IsUntitled then
-    HandleSaveAsClick(Sender)
-  else
-    SaveToFile(FActiveDoc.FileName);
+  FController.Save;
 end;
 
 procedure TMarkdownPadVCLForm.HandleSaveAsClick(Sender: TObject);
 begin
-  if FActiveDoc = nil then
-    Exit;
-
-  if not FActiveDoc.IsUntitled then
-    dlgSave.FileName := FActiveDoc.FileName;
-
-  if dlgSave.Execute then
-    SaveToFile(dlgSave.FileName);
+  FController.SaveAs;
 end;
 
 procedure TMarkdownPadVCLForm.HandleRecentClick(Sender: TObject);
@@ -842,26 +790,22 @@ end;
 
 procedure TMarkdownPadVCLForm.DoExportHtml;
 begin
-  if FActiveDoc <> nil then
-    FActiveDoc.Text := mdEditor.Text;
+  FController.ExportHtml;
+end;
 
-  var Title := UntitledName;
-  if FActiveDoc <> nil then
-    Title := FActiveDoc.DisplayName;
+function TMarkdownPadVCLForm.PromptExportHtml(const SuggestedName: string; out FileName: string): Boolean;
+begin
+  if SuggestedName <> '' then
+    dlgSaveHtml.FileName := SuggestedName;
 
-  dlgSaveHtml.FileName := TPath.ChangeExtension(Title, '.' + HtmlExtension);
-
-  if not dlgSaveHtml.Execute then
-    Exit;
-
-  const Html = TMarkdownHtmlExport.BuildDocument(mdEditor.Text, Title, FDarkThemeActive);
-  TFile.WriteAllText(dlgSaveHtml.FileName, Html, TEncoding.UTF8);
+  Result := dlgSaveHtml.Execute;
+  if Result then
+    FileName := dlgSaveHtml.FileName;
 end;
 
 procedure TMarkdownPadVCLForm.DoCopyHtml;
 begin
-  const Fragment = TMarkdown.ToHtml(mdEditor.Text, TMarkdownDialect.Gfm);
-  CopyHtmlToClipboard(Fragment);
+  FController.CopyHtml;
 end;
 
 procedure TMarkdownPadVCLForm.CopyHtmlToClipboard(const Fragment: string);
@@ -1066,20 +1010,7 @@ end;
 
 procedure TMarkdownPadVCLForm.HandleEditorChange(Sender: TObject);
 begin
-  if FSwapping then
-    Exit;
-
-  const WasModified = (FActiveDoc <> nil) and FActiveDoc.Modified;
-
-  if FActiveDoc <> nil then
-    FActiveDoc.Modified := True;
-
-  FMapDirty := True;
-
-  if not WasModified then
-    RebuildTabs;
-
-  UpdateTitle;
+  FController.NotifyEditorChanged;
 end;
 
 procedure TMarkdownPadVCLForm.HandleSyncScroll(Sender: TObject; const SourceLine: Integer);
@@ -1097,16 +1028,16 @@ end;
 procedure TMarkdownPadVCLForm.HandleTocListClick(Sender: TObject);
 begin
   const Index = lstToc.ItemIndex;
-  if (Index < 0) or (Index > High(FTocEntries)) then
+  if (Index < 0) or (Index >= FController.TocEntryCount) then
     Exit;
 
   if FMapDirty then
     RebuildSyncAndToc;
 
-  if (Index < 0) or (Index > High(FTocEntries)) then
+  if (Index < 0) or (Index >= FController.TocEntryCount) then
     Exit;
 
-  const SourceLine = FTocEntries[Index].SourceLine - 1;
+  const SourceLine = FController.TocSourceLine(Index);
 
   // Scrolling the editor drives the preview through the linked SyncScroll.
   mdEditor.CaretPosition := mdEditor.SourceLineStartOffset(SourceLine);
@@ -1118,74 +1049,12 @@ end;
 
 procedure TMarkdownPadVCLForm.HandleTick(Sender: TObject);
 begin
-  if FMapDirty then
-    RebuildSyncAndToc;
-
-  UpdateStatusBar;
-
-  FWatcher.Poll;
-end;
-
-procedure TMarkdownPadVCLForm.HandleFileChanged(const Document: IPadDocument);
-begin
-  if Document.Modified then
-  begin
-    if MessageDlg(ReloadPrompt, mtConfirmation, [mbYes, mbNo], 0) <> mrYes then
-      Exit;
-  end;
-
-  var NewText: string;
-  try
-    NewText := TFile.ReadAllText(Document.FileName);
-  except
-    Document.DiskTimestampUtc := 0;
-    Exit;
-  end;
-
-  Document.Text := NewText;
-  Document.Modified := False;
-
-  if Document = FActiveDoc then
-  begin
-    FSwapping := True;
-    try
-      mdEditor.Text := NewText;
-      mdEditor.FlushPreview;
-
-      if mdEditor.CaretPosition > System.Length(NewText) then
-        mdEditor.CaretPosition := System.Length(NewText);
-    finally
-      FSwapping := False;
-    end;
-
-    FMapDirty := True;
-  end;
-
-  RebuildTabs;
-  UpdateTitle;
+  FController.Tick;
 end;
 
 procedure TMarkdownPadVCLForm.OpenPath(const FileName: string);
 begin
-  if not TFile.Exists(FileName) then
-    Exit;
-
-  var Document: IPadDocument;
-  try
-    Document := FWorkspace.OpenFile(FileName);
-  except
-    on E: Exception do
-    begin
-      MessageDlg(E.Message, mtError, [mbOK], 0);
-      Exit;
-    end;
-  end;
-
-  FWatcher.Reset(Document);
-  FSession.AddRecentFile(FileName);
-
-  RebuildTabs;
-  SwitchToDocument(FWorkspace.ActiveIndex);
+  FController.OpenPath(FileName);
 end;
 
 function TMarkdownPadVCLForm.GetEditorText: string;
@@ -1255,132 +1124,125 @@ end;
 
 procedure TMarkdownPadVCLForm.SwitchToDocument(const Index: Integer);
 begin
-  if FSwapping then
-    Exit;
-
-  FActiveDoc := TPadDocumentSwitch.Execute(FWorkspace, Self, FActiveDoc, Index);
-
-  if FActiveDoc = nil then
-    Exit;
-
-  FLastCaret := -1;
-  FMapDirty := True;
-
-  RebuildTabs;
-  UpdateTitle;
+  FController.SwitchToDocument(Index);
 end;
 
 procedure TMarkdownPadVCLForm.CloseActiveDocument;
 begin
-  CloseDocumentAt(FWorkspace.ActiveIndex);
+  FController.CloseActiveDocument;
 end;
 
 procedure TMarkdownPadVCLForm.CloseDocumentAt(const Index: Integer);
 begin
-  if (Index < 0) or (Index >= FWorkspace.Count) then
-    Exit;
-
-  if Index <> FWorkspace.ActiveIndex then
-    SwitchToDocument(Index);
-
-  if FActiveDoc = nil then
-    Exit;
-
-  if FActiveDoc.Modified then
-  begin
-    const Answer = MessageDlg(CloseUnsavedPrompt, mtConfirmation, [mbYes, mbNo, mbCancel], 0);
-    if Answer = mrCancel then
-      Exit;
-
-    if (Answer = mrYes) and not SaveActiveDocument then
-      Exit;
-  end;
-
-  FWorkspace.CloseDocument(FWorkspace.ActiveIndex);
-  FActiveDoc := nil;
-
-  if FWorkspace.Count = 0 then
-  begin
-    Close;
-    Exit;
-  end;
-
-  RebuildTabs;
-  SwitchToDocument(FWorkspace.ActiveIndex);
-end;
-
-function TMarkdownPadVCLForm.SaveActiveDocument: Boolean;
-begin
-  if FActiveDoc = nil then
-    Exit(False);
-
-  FActiveDoc.Text := mdEditor.Text;
-
-  if FActiveDoc.IsUntitled then
-  begin
-    if not dlgSave.Execute then
-      Exit(False);
-
-    SaveToFile(dlgSave.FileName);
-  end
-  else
-    SaveToFile(FActiveDoc.FileName);
-
-  Result := True;
-end;
-
-procedure TMarkdownPadVCLForm.SaveToFile(const FileName: string);
-begin
-  TFile.WriteAllText(FileName, mdEditor.Text);
-
-  FActiveDoc.Text := mdEditor.Text;
-  FActiveDoc.FileName := FileName;
-  FActiveDoc.Modified := False;
-
-  FWatcher.Reset(FActiveDoc);
-  FSession.AddRecentFile(FileName);
-
-  RebuildTabs;
-  UpdateTitle;
+  FController.CloseDocumentAt(Index);
 end;
 
 procedure TMarkdownPadVCLForm.RestoreSession;
 begin
-  if not TPadSessionSync.RestoreOpenFiles(FWorkspace, FSession) then
-  begin
-    const Document = FWorkspace.NewDocument;
-    Document.Text := BuildSampleMarkdown;
-  end;
-
-  for var Index := 0 to FWorkspace.Count - 1 do
-  begin
-    FWatcher.Reset(FWorkspace.Documents[Index]);
-  end;
-
-  RebuildTabs;
-  SwitchToDocument(FWorkspace.ActiveIndex);
-
-  FViewMode := FSession.ViewMode;
-  ApplyViewMode;
+  FController.RestoreSession;
 end;
 
 procedure TMarkdownPadVCLForm.SaveSession;
 begin
-  if FActiveDoc <> nil then
-    FActiveDoc.Text := mdEditor.Text;
+  FController.SaveSession;
+end;
 
-  var FilteredActive: Integer;
-  const Titled = TPadSessionSync.CollectOpenFiles(FWorkspace, FilteredActive);
+function TMarkdownPadVCLForm.GetWorkspace: IPadWorkspace;
+begin
+  Result := FController.Workspace;
+end;
 
-  FSession.SetOpenFiles(Titled, FilteredActive);
-  FSession.DarkTheme := FDarkThemeActive;
+function TMarkdownPadVCLForm.GetSession: TPadSession;
+begin
+  Result := FController.Session;
+end;
 
+function TMarkdownPadVCLForm.GetMapDirty: Boolean;
+begin
+  Result := FController.MapDirty;
+end;
+
+procedure TMarkdownPadVCLForm.SetMapDirty(const Value: Boolean);
+begin
+  FController.MapDirty := Value;
+end;
+
+function TMarkdownPadVCLForm.GetSwapping: Boolean;
+begin
+  Result := FController.Swapping;
+end;
+
+procedure TMarkdownPadVCLForm.SetSwapping(const Value: Boolean);
+begin
+  FController.Swapping := Value;
+end;
+
+function TMarkdownPadVCLForm.GetPaletteMatches: TArray<TPadCommandMatch>;
+begin
+  Result := FController.PaletteMatches;
+end;
+
+function TMarkdownPadVCLForm.SampleMarkdown: string;
+begin
+  Result := BuildSampleMarkdown;
+end;
+
+function TMarkdownPadVCLForm.DarkThemeActive: Boolean;
+begin
+  Result := FDarkThemeActive;
+end;
+
+function TMarkdownPadVCLForm.EffectiveViewMode: TPadViewMode;
+begin
   if FZenActive then
-    FSession.ViewMode := FPreZenViewMode
+    Result := FPreZenViewMode
   else
-    FSession.ViewMode := FViewMode;
+    Result := FViewMode;
+end;
 
-  FSession.Save;
+procedure TMarkdownPadVCLForm.ApplyRestoredViewMode(const Mode: TPadViewMode);
+begin
+  FViewMode := Mode;
+  ApplyViewMode;
+end;
+
+function TMarkdownPadVCLForm.PromptOpenFile(out FileName: string): Boolean;
+begin
+  Result := dlgOpen.Execute;
+  if Result then
+    FileName := dlgOpen.FileName;
+end;
+
+function TMarkdownPadVCLForm.PromptSaveFile(const SuggestedName: string; out FileName: string): Boolean;
+begin
+  if SuggestedName <> '' then
+    dlgSave.FileName := SuggestedName;
+
+  Result := dlgSave.Execute;
+  if Result then
+    FileName := dlgSave.FileName;
+end;
+
+function TMarkdownPadVCLForm.ConfirmClose: TPadCloseChoice;
+begin
+  const Answer = MessageDlg(CloseUnsavedPrompt, mtConfirmation, [mbYes, mbNo, mbCancel], 0);
+
+  if Answer = mrCancel then
+    Result := TPadCloseChoice.Cancel
+  else if Answer = mrYes then
+    Result := TPadCloseChoice.Save
+  else
+    Result := TPadCloseChoice.Discard;
+end;
+
+procedure TMarkdownPadVCLForm.ShowOpenError(const FileName, ErrorMessage: string);
+begin
+  MessageDlg(ErrorMessage, mtError, [mbOK], 0);
+end;
+
+procedure TMarkdownPadVCLForm.CloseApplication;
+begin
+  Close;
 end;
 
 procedure TMarkdownPadVCLForm.RebuildTabs;
@@ -1470,67 +1332,95 @@ end;
 
 procedure TMarkdownPadVCLForm.RebuildSyncAndToc;
 begin
-  FMapDirty := False;
+  FController.RebuildSyncAndToc;
+end;
 
-  const Document = TMarkdown.Parse(mdEditor.Text, TMarkdownDialect.Gfm);
+procedure TMarkdownPadVCLForm.UpdateActiveTocEntry(const SourceLine: Integer);
+begin
+  FController.UpdateActiveTocEntry(SourceLine);
+end;
 
-  const Outline = TPadOutlineBuilder.Build(TMarkdownToc.FromDocument(Document));
-  FTocEntries := Outline.Entries;
+procedure TMarkdownPadVCLForm.ExecuteFind;
+begin
+  FController.ExecuteFind;
+end;
 
+procedure TMarkdownPadVCLForm.SetDocumentTitle(const Name: string);
+begin
+  Caption := Format(TitleFormat, [WindowCaption, Name]);
+end;
+
+procedure TMarkdownPadVCLForm.SetStatus(const PositionText, WordsText: string);
+begin
+  lblPos.Caption := PositionText;
+  lblWords.Caption := WordsText;
+end;
+
+procedure TMarkdownPadVCLForm.SetTocCaptions(const Captions: TArray<string>);
+begin
   lstToc.Items.BeginUpdate;
   try
     lstToc.Items.Clear;
 
-    for var Caption in Outline.Captions do
+    for var Caption in Captions do
       lstToc.Items.Add(Caption);
   finally
     lstToc.Items.EndUpdate;
   end;
 end;
 
-procedure TMarkdownPadVCLForm.UpdateActiveTocEntry(const SourceLine: Integer);
+procedure TMarkdownPadVCLForm.SetActiveTocIndex(const Index: Integer);
 begin
-  const Best = TPadOutlineBuilder.ActiveIndex(FTocEntries, SourceLine);
-
-  if Best <> lstToc.ItemIndex then
-    lstToc.ItemIndex := Best;
+  if Index <> lstToc.ItemIndex then
+    lstToc.ItemIndex := Index;
 end;
 
-procedure TMarkdownPadVCLForm.UpdateStatusBar;
+function TMarkdownPadVCLForm.EditorFindNeedle: string;
 begin
-  const Caret = mdEditor.CaretPosition;
-  if Caret = FLastCaret then
-    Exit;
-
-  FLastCaret := Caret;
-
-  var Line, Column: Integer;
-  TPadText.ComputeLineColumn(mdEditor.Text, Caret, Line, Column);
-  lblPos.Caption := Format(StatusPositionFormat, [Line, Column]);
-  lblWords.Caption := Format(StatusWordsFormat, [TPadText.CountWords(mdEditor.Text)]);
+  Result := edtEditorFind.Text;
 end;
 
-procedure TMarkdownPadVCLForm.UpdateTitle;
+function TMarkdownPadVCLForm.PreviewFindNeedle: string;
 begin
-  var Name := UntitledName;
-
-  if FActiveDoc <> nil then
-  begin
-    Name := FActiveDoc.DisplayName;
-    if FActiveDoc.Modified then
-      Name := Name + ModifiedMarker;
-  end;
-
-  Caption := Format(TitleFormat, [WindowCaption, Name]);
+  Result := FFindEdit.Text;
 end;
 
-procedure TMarkdownPadVCLForm.ExecuteFind;
+procedure TMarkdownPadVCLForm.SetFindCount(const Value: string);
 begin
-  const Needle = FFindEdit.Text;
-  if Needle = '' then
-    Exit;
+  lblFindCount.Caption := Value;
+end;
 
+procedure TMarkdownPadVCLForm.EditorFindNext(const Needle: string);
+begin
+  mdEditor.FindNext(Needle);
+end;
+
+function TMarkdownPadVCLForm.EditorFindMatchCount(const Needle: string): Integer;
+begin
+  Result := mdEditor.FindMatchCount(Needle);
+end;
+
+procedure TMarkdownPadVCLForm.PreviewFindText(const Needle: string);
+begin
   mdPreview.FindText(Needle);
+end;
+
+function TMarkdownPadVCLForm.ConfirmCloseDocument(const DocName: string): TPadCloseChoice;
+begin
+  const Answer = MessageDlg(Format(CloseDocumentPromptFormat, [DocName]), mtConfirmation,
+    [mbYes, mbNo, mbCancel], 0);
+
+  if Answer = mrCancel then
+    Result := TPadCloseChoice.Cancel
+  else if Answer = mrYes then
+    Result := TPadCloseChoice.Save
+  else
+    Result := TPadCloseChoice.Discard;
+end;
+
+function TMarkdownPadVCLForm.ConfirmReload: Boolean;
+begin
+  Result := MessageDlg(ReloadPrompt, mtConfirmation, [mbYes, mbNo], 0) = mrYes;
 end;
 
 procedure TMarkdownPadVCLForm.BuildPalette;
@@ -1565,43 +1455,37 @@ end;
 
 procedure TMarkdownPadVCLForm.BuildCommandRegistry;
 begin
-  FCommands := TPadCommandRegistry.Create;
-
-  RegisterStaticCommands;
+  FController.InitCommandRegistry(BuildCommandActions);
 end;
 
-procedure TMarkdownPadVCLForm.RegisterStaticCommands;
-var
-  Actions: TPadCommandActions;
+function TMarkdownPadVCLForm.BuildCommandActions: TPadCommandActions;
 begin
-  Actions.NewDocument := procedure begin HandleNewClick(nil); end;
-  Actions.OpenDocument := procedure begin HandleOpenClick(nil); end;
-  Actions.Save := procedure begin HandleSaveClick(nil); end;
-  Actions.SaveAs := procedure begin HandleSaveAsClick(nil); end;
-  Actions.CloseDocument := procedure begin CloseActiveDocument; end;
-  Actions.NextTab :=
+  Result.NewDocument := procedure begin HandleNewClick(nil); end;
+  Result.OpenDocument := procedure begin HandleOpenClick(nil); end;
+  Result.Save := procedure begin HandleSaveClick(nil); end;
+  Result.SaveAs := procedure begin HandleSaveAsClick(nil); end;
+  Result.CloseDocument := procedure begin CloseActiveDocument; end;
+  Result.NextTab :=
     procedure
     begin
       FWorkspace.ActivateNext;
       SwitchToDocument(FWorkspace.ActiveIndex);
     end;
-  Actions.ExportHtml := procedure begin DoExportHtml; end;
-  Actions.CopyHtml := procedure begin DoCopyHtml; end;
-  Actions.ViewEditorOnly := procedure begin SetViewMode(TPadViewMode.EditorOnly); end;
-  Actions.ViewSplit := procedure begin SetViewMode(TPadViewMode.Split); end;
-  Actions.ViewPreviewOnly := procedure begin SetViewMode(TPadViewMode.PreviewOnly); end;
-  Actions.ToggleZen := procedure begin ToggleZen; end;
-  Actions.ToggleTheme := procedure begin HandleThemeClick(nil); end;
-  Actions.ToggleToc := procedure begin HandleTocClick(nil); end;
-  Actions.ShowFind := procedure begin ShowFindBar; end;
-  Actions.FindInPreview := procedure begin ExecuteFind; end;
-  Actions.ExecuteFormat :=
+  Result.ExportHtml := procedure begin DoExportHtml; end;
+  Result.CopyHtml := procedure begin DoCopyHtml; end;
+  Result.ViewEditorOnly := procedure begin SetViewMode(TPadViewMode.EditorOnly); end;
+  Result.ViewSplit := procedure begin SetViewMode(TPadViewMode.Split); end;
+  Result.ViewPreviewOnly := procedure begin SetViewMode(TPadViewMode.PreviewOnly); end;
+  Result.ToggleZen := procedure begin ToggleZen; end;
+  Result.ToggleTheme := procedure begin HandleThemeClick(nil); end;
+  Result.ToggleToc := procedure begin HandleTocClick(nil); end;
+  Result.ShowFind := procedure begin ShowFindBar; end;
+  Result.FindInPreview := procedure begin ExecuteFind; end;
+  Result.ExecuteFormat :=
     procedure(const Command: TEditorCommand)
     begin
       ExecuteFormatCommand(Command);
     end;
-
-  RegisterStaticPadCommands(FCommands, Actions);
 end;
 
 procedure TMarkdownPadVCLForm.SetViewMode(const Mode: TPadViewMode);
@@ -1726,35 +1610,12 @@ end;
 
 procedure TMarkdownPadVCLForm.FindInEditor;
 begin
-  const Needle = edtEditorFind.Text;
-  if Needle = '' then
-  begin
-    UpdateFindCount;
-    Exit;
-  end;
-
-  mdEditor.FindNext(Needle);
-
-  UpdateFindCount;
+  FController.FindInEditor;
 end;
 
 procedure TMarkdownPadVCLForm.UpdateFindCount;
 begin
-  const Needle = edtEditorFind.Text;
-  if Needle = '' then
-  begin
-    lblFindCount.Caption := EmptyFindCaption;
-    Exit;
-  end;
-
-  const Total = mdEditor.FindMatchCount(Needle);
-
-  if Total = 0 then
-    lblFindCount.Caption := NoMatchCaption
-  else if Total = 1 then
-    lblFindCount.Caption := SingleMatchCaption
-  else
-    lblFindCount.Caption := Format(MatchCountFormat, [Total]);
+  FController.UpdateFindCount;
 end;
 
 procedure TMarkdownPadVCLForm.HandleEditorFindChange(Sender: TObject);
@@ -1764,18 +1625,7 @@ end;
 
 procedure TMarkdownPadVCLForm.ShowPalette;
 begin
-  FCommands.Clear;
-  RegisterStaticCommands;
-
-  for var Path in FSession.RecentFiles do
-  begin
-    const RecentPath = Path;
-    FCommands.Register(RecentPath, CatRecent, RecentShortcut,
-      procedure
-      begin
-        OpenPath(RecentPath);
-      end);
-  end;
+  FController.RebuildPaletteCommands;
 
   FPaletteEdit.Text := '';
   RefreshPaletteList;
@@ -1797,7 +1647,7 @@ end;
 
 procedure TMarkdownPadVCLForm.RefreshPaletteList;
 begin
-  FPaletteMatches := FCommands.Match(FPaletteEdit.Text);
+  FController.RefreshMatches(FPaletteEdit.Text);
 
   FPaletteList.Items.BeginUpdate;
   try
@@ -1873,15 +1723,12 @@ end;
 procedure TMarkdownPadVCLForm.ExecuteSelectedCommand;
 begin
   const Index = FPaletteList.ItemIndex;
-  if (Index < 0) or (Index > High(FPaletteMatches)) then
+  if (Index < 0) or (Index >= FController.PaletteMatchCount) then
     Exit;
-
-  const Action = FPaletteMatches[Index].Command.Action;
 
   ClosePalette;
 
-  if Assigned(Action) then
-    Action();
+  FController.InvokePaletteCommand(Index);
 end;
 
 procedure TMarkdownPadVCLForm.ToggleZen;

--- a/Examples/MarkdownPadVCL/MarkdownPadVCL.dpr
+++ b/Examples/MarkdownPadVCL/MarkdownPadVCL.dpr
@@ -16,7 +16,10 @@ uses
   MarkdownPadVCL.Main in 'MarkdownPadVCL.Main.pas' {MarkdownPadVCLForm},
   MarkdownPad.Defines in '..\Shared\MarkdownPad.Defines.pas',
   MarkdownPad.Text in '..\Shared\MarkdownPad.Text.pas',
-  MarkdownPad.Outline in '..\Shared\MarkdownPad.Outline.pas';
+  MarkdownPad.Outline in '..\Shared\MarkdownPad.Outline.pas',
+  MarkdownPadVCL.Defines in 'MarkdownPadVCL.Defines.pas',
+  MarkdownPad.Shell in '..\Shared\MarkdownPad.Shell.pas',
+  MarkdownPad.Controller in '..\Shared\MarkdownPad.Controller.pas';
 
 {$R *.res}
 

--- a/Examples/MarkdownPadVCL/MarkdownPadVCL.dproj
+++ b/Examples/MarkdownPadVCL/MarkdownPadVCL.dproj
@@ -98,7 +98,6 @@
         </DelphiCompile>
         <DCCReference Include="..\Shared\MarkdownPad.Workspace.Interfaces.pas"/>
         <DCCReference Include="..\Shared\MarkdownPad.Workspace.pas"/>
-        <DCCReference Include="..\Shared\MarkdownPad.EditorView.pas"/>
         <DCCReference Include="..\Shared\MarkdownPad.Session.pas"/>
         <DCCReference Include="..\Shared\MarkdownPad.Commands.pas"/>
         <DCCReference Include="..\Shared\MarkdownPad.TabStrip.Layout.pas"/>
@@ -115,6 +114,9 @@
         <DCCReference Include="..\Shared\MarkdownPad.Defines.pas"/>
         <DCCReference Include="..\Shared\MarkdownPad.Text.pas"/>
         <DCCReference Include="..\Shared\MarkdownPad.Outline.pas"/>
+        <DCCReference Include="MarkdownPadVCL.Defines.pas"/>
+        <DCCReference Include="..\Shared\MarkdownPad.Shell.pas"/>
+        <DCCReference Include="..\Shared\MarkdownPad.Controller.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>

--- a/Examples/Shared/MarkdownPad-Sharing-TODO.md
+++ b/Examples/Shared/MarkdownPad-Sharing-TODO.md
@@ -20,8 +20,32 @@ twee schillen om dezelfde app. De echt identieke stukken zijn al uitgetild naar
   scroll-naar-bronregel, swap-suppressie) en `TPadDocumentSwitch.Execute` (de
   buffer-swap: uitgaand document opslaan, doel activeren, inkomend document laden).
   Elke form implementeert `IPadEditorView` met triviale forwarders naar zijn eigen
-  `mdEditor`/`mdPreview` (VCL) resp. `FEditor`/`FPreview` (FMX); `SwitchToDocument`
-  is nu een paar regels die `TPadDocumentSwitch.Execute` aanroepen.
+  `mdEditor`/`mdPreview` (VCL) resp. `FEditor`/`FPreview` (FMX).
+- `MarkdownPad.Shell.pas` — `IPadShell`: de seam waarmee de controller de
+  framework-specifieke schil aanstuurt (tab-strip, titel, dialogs, clipboard,
+  per-app tekst zoals `SampleMarkdown`). Elke form implementeert deze interface.
+- `MarkdownPad.Controller.pas` — `TPadController`: framework-agnostische
+  orkestratie. Bezit het document-model (workspace/session/file-watcher) en de
+  applicatielogica die eerst verbatim in beide forms stond. Praat met de editor
+  via `IPadEditorView` en met de schil via `IPadShell`; raakt nooit een VCL/FMX-
+  control aan. **Gefaseerde extractie — nu verhuisd:** document-lifecycle (nieuw
+  document, openen, opslaan/opslaan-als, sluiten, document wisselen, sessie
+  herstellen/bewaren); de command-palette (registry-opbouw, recent-files,
+  fuzzy-match, commando uitvoeren; de form levert de actie-closures + rendert de
+  lijst); de **editing-loop** (editor-change, tick, status/titel, find,
+  TOC-sync, extern-gewijzigd-bestand herladen, close-query); en **HTML-export/
+  copy** (de controller genereert het document/fragment via `TMarkdownHtmlExport`
+  / `TMarkdown.ToHtml`, de form doet de save-dialog en het klembord). De
+  `FTocFollowing`-reentrancy-guard blijft bewust FMX-only (VCL's lijst vuurt geen
+  change op een programmatische `ItemIndex`).
+
+### Bewust NIET naar de controller
+- **View-mode + zen** (`ApplyViewMode`, `SetViewMode`, `EnterZen`/`ExitZen`,
+  `UpdateZenPadding`): dit is view-logica, geen app-logica. Elke regel is
+  framework-specifiek (pane-visibility/align, `TPanel`/`TLayout` pad-panelen,
+  `TColor` vs `TAlphaColor`, `ClientWidth`); de gedeelde kern is ~5 regels en
+  loopt al via de `EffectiveViewMode` / `ApplyRestoredViewMode`-seams. De
+  controller hoort niks te weten van pad-panelen en pane-alignment.
 
 ## Nog niet gedeeld (bewust uitgesteld)
 

--- a/Examples/Shared/MarkdownPad.Controller.pas
+++ b/Examples/Shared/MarkdownPad.Controller.pas
@@ -1,0 +1,583 @@
+unit MarkdownPad.Controller;
+
+// Framework-agnostic orchestration for the Markdown4D Pad demo: owns the
+// document model (workspace/session/file-watcher) and the application logic
+// shared by the VCL and FMX forms. It reaches the live editor/preview through
+// IPadEditorView and the chrome/dialogs through IPadShell, so it never touches
+// a VCL or FMX control directly.
+
+interface
+
+uses
+  Markdown4D.Toc,
+  MarkdownPad.Workspace.Interfaces,
+  MarkdownPad.Session,
+  MarkdownPad.FileWatcher,
+  MarkdownPad.EditorView,
+  MarkdownPad.Commands,
+  MarkdownPad.CommandSet,
+  MarkdownPad.Shell;
+
+type
+  TPadController = class
+  private
+    FEditor: IPadEditorView;
+    FShell: IPadShell;
+    FWorkspace: IPadWorkspace;
+    FSession: TPadSession;
+    FWatcher: TPadFileWatcher;
+    FActiveDoc: IPadDocument;
+    FMapDirty: Boolean;
+    FSwapping: Boolean;
+    FLastCaret: Integer;
+    FCommands: TPadCommandRegistry;
+    FActions: TPadCommandActions;
+    FPaletteMatches: TArray<TPadCommandMatch>;
+    FTocEntries: TArray<IMarkdownTocEntry>;
+    procedure UpdateTitle;
+    procedure UpdateStatusBar;
+    procedure DoFileChanged(const Document: IPadDocument);
+  public
+    constructor Create(const Editor: IPadEditorView; const Shell: IPadShell;
+      const SessionFileName: string);
+    destructor Destroy; override;
+
+    // Document lifecycle.
+    procedure NewDocument;
+    procedure OpenViaDialog;
+    procedure OpenPath(const FileName: string);
+    procedure Save;
+    procedure SaveAs;
+    function SaveActiveDocument: Boolean;
+    procedure SaveToFile(const FileName: string);
+    procedure SwitchToDocument(const Index: Integer);
+    procedure CloseActiveDocument;
+    procedure CloseDocumentAt(const Index: Integer);
+    procedure RestoreSession;
+    procedure SaveSession;
+
+    // Command palette: the form supplies the action closures (they target its
+    // own methods) and renders the list; the controller owns the registry, the
+    // recent-file assembly and the matcher.
+    procedure InitCommandRegistry(const Actions: TPadCommandActions);
+    procedure RebuildPaletteCommands;
+    procedure RefreshMatches(const Query: string);
+    function PaletteMatchCount: Integer;
+    procedure InvokePaletteCommand(const Index: Integer);
+
+    // Editing loop: the form's event handlers and find bar delegate here; the
+    // controller owns the state and drives the chrome through IPadShell and the
+    // editor through IPadEditorView.
+    procedure NotifyEditorChanged;
+    procedure Tick;
+    procedure RebuildSyncAndToc;
+    procedure UpdateActiveTocEntry(const SourceLine: Integer);
+    function TocEntryCount: Integer;
+    function TocSourceLine(const Index: Integer): Integer;
+    procedure FindInEditor;
+    procedure UpdateFindCount;
+    procedure ExecuteFind;
+    procedure ExportHtml;
+    procedure CopyHtml;
+    function QueryClose: Boolean;
+
+    // Model state the form reads back through its own accessors.
+    property Workspace: IPadWorkspace read FWorkspace;
+    property Session: TPadSession read FSession;
+    property Watcher: TPadFileWatcher read FWatcher;
+    property ActiveDocument: IPadDocument read FActiveDoc;
+    property MapDirty: Boolean read FMapDirty write FMapDirty;
+    property Swapping: Boolean read FSwapping write FSwapping;
+    property LastCaret: Integer read FLastCaret write FLastCaret;
+    property PaletteMatches: TArray<TPadCommandMatch> read FPaletteMatches;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.IOUtils,
+  Markdown4D,
+  Markdown4D.Defines,
+  MarkdownPad.Defines,
+  MarkdownPad.Text,
+  MarkdownPad.Outline,
+  MarkdownPad.HtmlExport,
+  MarkdownPad.Workspace,
+  MarkdownPad.SessionSync;
+
+constructor TPadController.Create(const Editor: IPadEditorView; const Shell: IPadShell;
+  const SessionFileName: string);
+begin
+  inherited Create;
+
+  FEditor := Editor;
+  FShell := Shell;
+
+  FWorkspace := TPadWorkspace.Create;
+  FSession := TPadSession.Create(TPadSession.ResolvePath(SessionFileName));
+  FSession.Load;
+  FWatcher := TPadFileWatcher.Create(FWorkspace, DoFileChanged);
+end;
+
+destructor TPadController.Destroy;
+begin
+  FCommands.Free;
+  FWatcher.Free;
+  FSession.Free;
+
+  inherited Destroy;
+end;
+
+procedure TPadController.NewDocument;
+begin
+  FWorkspace.NewDocument;
+  SwitchToDocument(FWorkspace.ActiveIndex);
+end;
+
+procedure TPadController.OpenViaDialog;
+begin
+  var FileName: string;
+  if FShell.PromptOpenFile(FileName) then
+    OpenPath(FileName);
+end;
+
+procedure TPadController.OpenPath(const FileName: string);
+begin
+  if not TFile.Exists(FileName) then
+    Exit;
+
+  var Document: IPadDocument;
+  try
+    Document := FWorkspace.OpenFile(FileName);
+  except
+    on E: Exception do
+    begin
+      FShell.ShowOpenError(FileName, E.Message);
+      Exit;
+    end;
+  end;
+
+  FWatcher.Reset(Document);
+  FSession.AddRecentFile(FileName);
+
+  FShell.RebuildTabs;
+  SwitchToDocument(FWorkspace.ActiveIndex);
+end;
+
+procedure TPadController.Save;
+begin
+  if FActiveDoc = nil then
+    Exit;
+
+  if FActiveDoc.IsUntitled then
+    SaveAs
+  else
+    SaveToFile(FActiveDoc.FileName);
+end;
+
+procedure TPadController.SaveAs;
+begin
+  if FActiveDoc = nil then
+    Exit;
+
+  var Suggested := '';
+  if not FActiveDoc.IsUntitled then
+    Suggested := FActiveDoc.FileName;
+
+  var FileName: string;
+  if FShell.PromptSaveFile(Suggested, FileName) then
+    SaveToFile(FileName);
+end;
+
+function TPadController.SaveActiveDocument: Boolean;
+begin
+  if FActiveDoc = nil then
+    Exit(False);
+
+  FActiveDoc.Text := FEditor.EditorText;
+
+  if FActiveDoc.IsUntitled then
+  begin
+    var FileName: string;
+    if not FShell.PromptSaveFile('', FileName) then
+      Exit(False);
+
+    SaveToFile(FileName);
+  end
+  else
+    SaveToFile(FActiveDoc.FileName);
+
+  Result := True;
+end;
+
+procedure TPadController.SaveToFile(const FileName: string);
+begin
+  FActiveDoc.Text := FEditor.EditorText;
+
+  TFile.WriteAllText(FileName, FActiveDoc.Text);
+
+  FActiveDoc.FileName := FileName;
+  FActiveDoc.Modified := False;
+
+  FWatcher.Reset(FActiveDoc);
+  FSession.AddRecentFile(FileName);
+
+  FShell.RebuildTabs;
+  UpdateTitle;
+end;
+
+procedure TPadController.SwitchToDocument(const Index: Integer);
+begin
+  if FSwapping then
+    Exit;
+
+  FActiveDoc := TPadDocumentSwitch.Execute(FWorkspace, FEditor, FActiveDoc, Index);
+
+  if FActiveDoc = nil then
+    Exit;
+
+  FLastCaret := -1;
+  FMapDirty := True;
+
+  FShell.RebuildTabs;
+  UpdateTitle;
+end;
+
+procedure TPadController.CloseActiveDocument;
+begin
+  CloseDocumentAt(FWorkspace.ActiveIndex);
+end;
+
+procedure TPadController.CloseDocumentAt(const Index: Integer);
+begin
+  if (Index < 0) or (Index >= FWorkspace.Count) then
+    Exit;
+
+  if Index <> FWorkspace.ActiveIndex then
+    SwitchToDocument(Index);
+
+  if FActiveDoc = nil then
+    Exit;
+
+  if FActiveDoc.Modified then
+  begin
+    const Choice = FShell.ConfirmClose;
+
+    if Choice = TPadCloseChoice.Cancel then
+      Exit;
+
+    if (Choice = TPadCloseChoice.Save) and not SaveActiveDocument then
+      Exit;
+  end;
+
+  const ClosingIndex = FWorkspace.ActiveIndex;
+  FActiveDoc := nil;
+  FWorkspace.CloseDocument(ClosingIndex);
+
+  if FWorkspace.Count = 0 then
+  begin
+    FShell.CloseApplication;
+    Exit;
+  end;
+
+  FShell.RebuildTabs;
+  SwitchToDocument(FWorkspace.ActiveIndex);
+end;
+
+procedure TPadController.RestoreSession;
+begin
+  if not TPadSessionSync.RestoreOpenFiles(FWorkspace, FSession) then
+  begin
+    const Document = FWorkspace.NewDocument;
+    Document.Text := FShell.SampleMarkdown;
+  end;
+
+  for var Index := 0 to FWorkspace.Count - 1 do
+    FWatcher.Reset(FWorkspace.Documents[Index]);
+
+  FShell.RebuildTabs;
+  SwitchToDocument(FWorkspace.ActiveIndex);
+
+  FShell.ApplyRestoredViewMode(FSession.ViewMode);
+end;
+
+procedure TPadController.SaveSession;
+begin
+  if FActiveDoc <> nil then
+    FActiveDoc.Text := FEditor.EditorText;
+
+  var FilteredActive: Integer;
+  const Titled = TPadSessionSync.CollectOpenFiles(FWorkspace, FilteredActive);
+
+  FSession.SetOpenFiles(Titled, FilteredActive);
+  FSession.DarkTheme := FShell.DarkThemeActive;
+  FSession.ViewMode := FShell.EffectiveViewMode;
+
+  FSession.Save;
+end;
+
+procedure TPadController.InitCommandRegistry(const Actions: TPadCommandActions);
+begin
+  FCommands := TPadCommandRegistry.Create;
+  FActions := Actions;
+
+  RegisterStaticPadCommands(FCommands, FActions);
+end;
+
+procedure TPadController.RebuildPaletteCommands;
+begin
+  FCommands.Clear;
+  RegisterStaticPadCommands(FCommands, FActions);
+
+  for var Path in FSession.RecentFiles do
+  begin
+    const RecentPath = Path;
+    FCommands.Register(RecentPath, CatRecent, RecentShortcut,
+      procedure
+      begin
+        OpenPath(RecentPath);
+      end);
+  end;
+end;
+
+procedure TPadController.RefreshMatches(const Query: string);
+begin
+  FPaletteMatches := FCommands.Match(Query);
+end;
+
+function TPadController.PaletteMatchCount: Integer;
+begin
+  Result := Length(FPaletteMatches);
+end;
+
+procedure TPadController.InvokePaletteCommand(const Index: Integer);
+begin
+  if (Index < 0) or (Index > High(FPaletteMatches)) then
+    Exit;
+
+  const Action = FPaletteMatches[Index].Command.Action;
+  if Assigned(Action) then
+    Action();
+end;
+
+procedure TPadController.UpdateTitle;
+begin
+  var Name := UntitledName;
+
+  if FActiveDoc <> nil then
+  begin
+    Name := FActiveDoc.DisplayName;
+    if FActiveDoc.Modified then
+      Name := Name + ModifiedMarker;
+  end;
+
+  FShell.SetDocumentTitle(Name);
+end;
+
+procedure TPadController.UpdateStatusBar;
+begin
+  const Caret = FEditor.EditorCaret;
+  if Caret = FLastCaret then
+    Exit;
+
+  FLastCaret := Caret;
+
+  const Text = FEditor.EditorText;
+
+  var Line, Column: Integer;
+  TPadText.ComputeLineColumn(Text, Caret, Line, Column);
+
+  const PositionText = Format(StatusPositionFormat, [Line, Column]);
+  const WordsText = Format(StatusWordsFormat, [TPadText.CountWords(Text)]);
+
+  FShell.SetStatus(PositionText, WordsText);
+end;
+
+procedure TPadController.NotifyEditorChanged;
+begin
+  if FSwapping then
+    Exit;
+
+  const WasModified = (FActiveDoc <> nil) and FActiveDoc.Modified;
+
+  if FActiveDoc <> nil then
+    FActiveDoc.Modified := True;
+
+  FMapDirty := True;
+
+  if not WasModified then
+    FShell.RebuildTabs;
+
+  UpdateTitle;
+end;
+
+procedure TPadController.Tick;
+begin
+  if FMapDirty then
+    RebuildSyncAndToc;
+
+  UpdateStatusBar;
+
+  FWatcher.Poll;
+end;
+
+procedure TPadController.RebuildSyncAndToc;
+begin
+  FMapDirty := False;
+
+  const Document = TMarkdown.Parse(FEditor.EditorText, TMarkdownDialect.Gfm);
+  const Outline = TPadOutlineBuilder.Build(TMarkdownToc.FromDocument(Document));
+
+  FTocEntries := Outline.Entries;
+
+  FShell.SetTocCaptions(Outline.Captions);
+end;
+
+procedure TPadController.UpdateActiveTocEntry(const SourceLine: Integer);
+begin
+  const Best = TPadOutlineBuilder.ActiveIndex(FTocEntries, SourceLine);
+  FShell.SetActiveTocIndex(Best);
+end;
+
+function TPadController.TocEntryCount: Integer;
+begin
+  Result := Length(FTocEntries);
+end;
+
+function TPadController.TocSourceLine(const Index: Integer): Integer;
+begin
+  Result := FTocEntries[Index].SourceLine - 1;
+end;
+
+procedure TPadController.FindInEditor;
+begin
+  const Needle = FShell.EditorFindNeedle;
+  if Needle = '' then
+  begin
+    UpdateFindCount;
+    Exit;
+  end;
+
+  FEditor.EditorFindNext(Needle);
+
+  UpdateFindCount;
+end;
+
+procedure TPadController.UpdateFindCount;
+begin
+  const Needle = FShell.EditorFindNeedle;
+  if Needle = '' then
+  begin
+    FShell.SetFindCount(EmptyFindCaption);
+    Exit;
+  end;
+
+  const Total = FEditor.EditorFindMatchCount(Needle);
+
+  if Total = 0 then
+    FShell.SetFindCount(NoMatchCaption)
+  else if Total = 1 then
+    FShell.SetFindCount(SingleMatchCaption)
+  else
+    FShell.SetFindCount(Format(MatchCountFormat, [Total]));
+end;
+
+procedure TPadController.ExecuteFind;
+begin
+  const Needle = FShell.PreviewFindNeedle;
+  if Needle = '' then
+    Exit;
+
+  FEditor.PreviewFindText(Needle);
+end;
+
+procedure TPadController.ExportHtml;
+begin
+  if FActiveDoc <> nil then
+    FActiveDoc.Text := FEditor.EditorText;
+
+  var Title := UntitledName;
+  if FActiveDoc <> nil then
+    Title := FActiveDoc.DisplayName;
+
+  const SuggestedName = TPath.ChangeExtension(Title, '.' + HtmlExtension);
+
+  var FileName: string;
+  if not FShell.PromptExportHtml(SuggestedName, FileName) then
+    Exit;
+
+  const Html = TMarkdownHtmlExport.BuildDocument(FEditor.EditorText, Title, FShell.DarkThemeActive);
+  TFile.WriteAllText(FileName, Html, TEncoding.UTF8);
+end;
+
+procedure TPadController.CopyHtml;
+begin
+  const Fragment = TMarkdown.ToHtml(FEditor.EditorText, TMarkdownDialect.Gfm);
+  FShell.CopyHtmlToClipboard(Fragment);
+end;
+
+function TPadController.QueryClose: Boolean;
+begin
+  for var Index := 0 to FWorkspace.Count - 1 do
+  begin
+    const Document = FWorkspace.Documents[Index];
+    if not Document.Modified then
+      Continue;
+
+    SwitchToDocument(Index);
+
+    case FShell.ConfirmCloseDocument(Document.DisplayName) of
+      TPadCloseChoice.Cancel:
+        Exit(False);
+      TPadCloseChoice.Save:
+        if not SaveActiveDocument then
+          Exit(False);
+    end;
+
+    Document.Modified := False;
+  end;
+
+  Result := True;
+end;
+
+procedure TPadController.DoFileChanged(const Document: IPadDocument);
+begin
+  if Document.Modified then
+  begin
+    if not FShell.ConfirmReload then
+      Exit;
+  end;
+
+  var NewText: string;
+  try
+    NewText := TFile.ReadAllText(Document.FileName);
+  except
+    Document.DiskTimestampUtc := 0;
+    Exit;
+  end;
+
+  Document.Text := NewText;
+  Document.Modified := False;
+
+  if Document = FActiveDoc then
+  begin
+    FSwapping := True;
+    try
+      FEditor.EditorText := NewText;
+      FEditor.FlushPreview;
+
+      if FEditor.EditorCaret > System.Length(NewText) then
+        FEditor.EditorCaret := System.Length(NewText);
+    finally
+      FSwapping := False;
+    end;
+
+    FMapDirty := True;
+  end;
+
+  FShell.RebuildTabs;
+  UpdateTitle;
+end;
+
+end.

--- a/Examples/Shared/MarkdownPad.Defines.pas
+++ b/Examples/Shared/MarkdownPad.Defines.pas
@@ -148,6 +148,9 @@ const
   CatFormat = 'Format';
   CatRecent = 'Recent';
 
+  // Shortcut label for dynamically-added recent-file palette entries.
+  RecentShortcut = '';
+
 implementation
 
 end.

--- a/Examples/Shared/MarkdownPad.EditorView.pas
+++ b/Examples/Shared/MarkdownPad.EditorView.pas
@@ -28,6 +28,11 @@ type
     function SaveEditState: IMarkdownEditorState;
     procedure LoadEditState(const State: IMarkdownEditorState);
     procedure FlushPreview;
+    // Find: highlight/advance in the editor, count matches, and search the
+    // rendered preview. Needles come from the form's find edits (via IPadShell).
+    procedure EditorFindNext(const Needle: string);
+    function EditorFindMatchCount(const Needle: string): Integer;
+    procedure PreviewFindText(const Needle: string);
     // Brackets the incoming-document load so the form suppresses its own change
     // handling while the editor and preview are repopulated.
     procedure BeginSwap;

--- a/Examples/Shared/MarkdownPad.Shell.pas
+++ b/Examples/Shared/MarkdownPad.Shell.pas
@@ -1,0 +1,54 @@
+unit MarkdownPad.Shell;
+
+// Seam between the framework-agnostic TPadController and the concrete VCL/FMX
+// form. The form implements IPadShell; the controller drives the chrome, tab
+// strip, dialogs and per-app text through it without knowing the framework.
+
+interface
+
+uses
+  MarkdownPad.Session;
+
+type
+  // Outcome of the "save before closing?" prompt.
+  TPadCloseChoice = (Save, Discard, Cancel);
+
+  IPadShell = interface
+    ['{2B7E4C10-9D3A-4F62-8E1C-1A6F0B5D7C34}']
+    // Chrome the controller refreshes after model changes.
+    procedure RebuildTabs;
+    procedure SetDocumentTitle(const Name: string);
+    procedure SetStatus(const PositionText, WordsText: string);
+    procedure ApplyRestoredViewMode(const Mode: TPadViewMode);
+
+    // Contents outline: the form owns the list control (and any framework-
+    // specific reentrancy guarding); the controller supplies the content.
+    procedure SetTocCaptions(const Captions: TArray<string>);
+    procedure SetActiveTocIndex(const Index: Integer);
+
+    // Find bar: needles come from the form's edits, the count label is a sink.
+    function EditorFindNeedle: string;
+    function PreviewFindNeedle: string;
+    procedure SetFindCount(const Value: string);
+
+    // Per-app / per-framework values the controller reads.
+    function SampleMarkdown: string;
+    function DarkThemeActive: Boolean;
+    function EffectiveViewMode: TPadViewMode;
+
+    // Dialogs and app lifetime, implemented with the native framework toolkit.
+    function PromptOpenFile(out FileName: string): Boolean;
+    function PromptSaveFile(const SuggestedName: string; out FileName: string): Boolean;
+    function PromptExportHtml(const SuggestedName: string; out FileName: string): Boolean;
+    function ConfirmClose: TPadCloseChoice;
+    function ConfirmCloseDocument(const DocName: string): TPadCloseChoice;
+    function ConfirmReload: Boolean;
+    procedure ShowOpenError(const FileName, ErrorMessage: string);
+    // Clipboard mechanism differs per framework (Win32 CF_HTML vs IFMXClipboardService).
+    procedure CopyHtmlToClipboard(const Fragment: string);
+    procedure CloseApplication;
+  end;
+
+implementation
+
+end.


### PR DESCRIPTION
Extract the application logic duplicated between the VCL and FMX MarkdownPad demos into a framework-agnostic `TPadController`, driven through `IPadEditorView` and a new `IPadShell` seam.

Moved to Examples/Shared (once, framework-agnostic):
- Document lifecycle (new/open/save/save-as/close, document switch, session restore/save)
- Command palette (registry, recent files, fuzzy match, execute)
- Editing loop (editor-change, tick, status/title, find, TOC-sync, external-reload, close-query)
- HTML export/copy generation

The forms keep only control construction, rendering and the two interface implementations. View-mode and zen stay in the forms as framework view logic; the `FTocFollowing` reentrancy guard stays FMX-only (VCL's list fires no change on a programmatic ItemIndex).

Also splits the per-app constants into `MarkdownPadVCL.Defines` / `MarkdownPadFMX.Defines` and moves the shared `RecentShortcut` into `MarkdownPad.Defines`.

Both VCL and FMX build clean with zero hints/warnings.